### PR TITLE
Remove anglicism in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Le tutoriel JavaScript moderne
 
-Ce repository héberge la traduction de <https://javascript.info> en français.
+Ce répertoire héberge la traduction de <https://javascript.info> en français.
 
 Aidez-nous à améliorer la traduction.
 


### PR DESCRIPTION
'repository' is an english word for which a correct linguistic translation would be 'répertoire'. This translation respects the technicalities of the original word.