### PR TITLE
Paterne -> Pattern

### DIFF
--- a/9-regular-expressions/12-regexp-backreferences/article.md
+++ b/9-regular-expressions/12-regexp-backreferences/article.md
@@ -1,10 +1,10 @@
-# Rétro référence dans le paterne : \N et \k<name>
+# Rétro référence dans le pattern : \N et \k<name>
 
-Nous pouvons utiliser le contenu des groupes de capture `pattern:(...)` non seulement dans le résultat ou dans la chaîne de caractères de remplacement, mais également dans le paterne en lui-même.
+Nous pouvons utiliser le contenu des groupes de capture `pattern:(...)` non seulement dans le résultat ou dans la chaîne de caractères de remplacement, mais également dans le pattern en lui-même.
 
 ## Rétro référence par un nombre : \N
 
-Un groupe peut être référencé dans le paterne par `pattern:\N`, où `N` est le numéro du groupe.
+Un groupe peut être référencé dans le pattern par `pattern:\N`, où `N` est le numéro du groupe.
 
 Pour rendre son utilité claire, considérons la tâche ci-dessous.
 
@@ -12,7 +12,7 @@ Nous devons trouver des chaînes citées : soit par des apostrophes `subject:'..
 
 Comment les trouver ?
 
-Nous pouvons mettre les deux types entre crochets : `pattern:['"](.*?)['"]`, mais ce paterne pourrait correspondre avec des mélanges comme `match:"...'` ou `match:'..."`. Cela mènerait à des correspondances incorrectes lorsqu'une citation apparaît dans une autre, comme dans le texte `subject:"She's the one!"`:
+Nous pouvons mettre les deux types entre crochets : `pattern:['"](.*?)['"]`, mais ce pattern pourrait correspondre avec des mélanges comme `match:"...'` ou `match:'..."`. Cela mènerait à des correspondances incorrectes lorsqu'une citation apparaît dans une autre, comme dans le texte `subject:"She's the one!"`:
 
 ```js run
 let str = `He said: "She's the one!".`;
@@ -23,9 +23,9 @@ let regexp = /['"](.*?)['"]/g;
 alert( str.match(regexp) ); // "She'
 ```
 
-Comme nous pouvons le voir, le paterne trouve des guillemets ouvrant `match:"`, puis le texte est récupéré jusqu'au `match:'`, ce qui termine la correspondance.
+Comme nous pouvons le voir, le pattern trouve des guillemets ouvrant `match:"`, puis le texte est récupéré jusqu'au `match:'`, ce qui termine la correspondance.
 
-Pour faire en sorte que le paterne vérifie que le caractère terminant la citation est précisément le même que celui qui l'ouvre, nous pouvons l'envelopper dans un groupe de capture et le rétro référencier : `pattern:(['"])(.*?)\1`.
+Pour faire en sorte que le pattern vérifie que le caractère terminant la citation est précisément le même que celui qui l'ouvre, nous pouvons l'envelopper dans un groupe de capture et le rétro référencier : `pattern:(['"])(.*?)\1`.
 
 Voilà le code correct :
 
@@ -41,7 +41,7 @@ alert( str.match(regexp) ); // "She's the one!"
 
 Maintenant, ça fonctionne ! Le moteur trouve le premier caractère de citation `pattern:(['"])` et mémorise son contenu. C'est le premier groupe de capture.
 
-Plus loin dans le paterne, `pattern:\1` signifie "cherche le même texte que dans le premier groupe de capture", le même caractère de citation dans notre cas.
+Plus loin dans le pattern, `pattern:\1` signifie "cherche le même texte que dans le premier groupe de capture", le même caractère de citation dans notre cas.
 
 Similairement, `pattern:\2` voudrait référencier le 2nd groupe, `pattern:\3` - le 3e groupe, et ainsi de suite.
 
@@ -49,8 +49,8 @@ Similairement, `pattern:\2` voudrait référencier le 2nd groupe, `pattern:\3` -
 Si nous utilisons `?:` dans le groupe, alors nous ne pouvons pas le référencer. Les groupes exclus de la capture `(?:...)` ne sont pas mémorisés par le moteur.
 ```
 
-```warn header="Ne mélangez pas : dans le paterne, `pattern:\1`, dans le replacement : `pattern:$1`"
-Dans la chaîne de remplacement, on utilise un signe dollar : `pattern:$1`, alors que dans un paterne - un antislash `pattern:\1`.
+```warn header="Ne mélangez pas : dans le pattern, `pattern:\1`, dans le replacement : `pattern:$1`"
+Dans la chaîne de remplacement, on utilise un signe dollar : `pattern:$1`, alors que dans un pattern - un antislash `pattern:\1`.
 ```
 
 ## Rétro référence par le nom: `\k<name>`


### PR DESCRIPTION
Correction : le mot "pattern" ne doit pas être traduit par "paterne" car ce sont deux mots différents (et ce dernier ne peut pas prendre le sens du premier) ; on doit donc laisser "pattern" tel quel