### PR TITLE
Fixed wrong priority of operators `??` and `||`

### DIFF
--- a/1-js/02-first-steps/12-nullish-coalescing-operator/article.md
+++ b/1-js/02-first-steps/12-nullish-coalescing-operator/article.md
@@ -107,7 +107,7 @@ En pratique, la hauteur zéro est souvent une valeur valide, qui ne doit pas êt
 
 ## Priorité
 
-La priorité de l'opérateur `??` est la même que celle de `||`. Elle est égale à `4` dans le [tableau MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table).
+La priorité de l'opérateur `??` est la même que celle de `||`. Elle est égale à `3` dans le [tableau MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#Table).
 
 Cela signifie que, tout comme `||`, l'opérateur de coalescence des nuls `??` est évalué avant `=` et `?`, Mais après la plupart des autres opérations, telles que `+`, `*`.
 


### PR DESCRIPTION
In the article `L'opérateur de coalescence des nuls '??'` the priority of the operators `??` and `||` was incorrect. This PR corrects that.