### PR TITLE
chore: fix incorrect french translation

### DIFF
--- a/2-ui/99-ui-misc/03-event-loop/article.md
+++ b/2-ui/99-ui-misc/03-event-loop/article.md
@@ -260,7 +260,7 @@ alert("code");
 Quel sera l'ordre ici?
 
 1. `code` s'affiche en premier, car il s'agit d'un appel synchrone régulier.
-2. `promesse` s'affiche en second, car `.then` passe par la file d'attente des microtâches et s'exécute après le code actuel.
+2. `promise` s'affiche en second, car `.then` passe par la file d'attente des microtâches et s'exécute après le code actuel.
 3. `timeout` s'affiche en dernier, car c'est une macrotâche.
 
 Une image, plus parlante, de la boucle d'événements ressemble à ceci (l'ordre est de haut en bas, c'est-à-dire: le script d'abord, puis les microtâches, le rendu, etc.):


### PR DESCRIPTION
The code is written in english so [this console log](https://github.com/javascript-tutorial/fr.javascript.info/commit/f9293128225b2caac6c6830c078945e9c34ddcc8#diff-b43ffe11af05abaed45d48a22b3df851828b0c23a7395e56edae64841e2ba070R255) not print "promesse" but "promise"