### PR TITLE
Corrige des traductions de 'Summary' et 'Language'

### DIFF
--- a/1-js/13-modules/01-modules-intro/article.md
+++ b/1-js/13-modules/01-modules-intro/article.md
@@ -234,7 +234,7 @@ Son contenu dépend de l'environnement. Dans le navigateur, il contient l'URL du
 
 ```html run height=0
 <script type="module">
-  alert(import.meta.url); // URL du script 
+  alert(import.meta.url); // URL du script
   // pour un script en ligne - l'URL de la page HTML actuelle
 </script>
 ```
@@ -398,7 +398,7 @@ Si nous utilisons des outils d'ensemble, alors que les scripts sont regroupés d
 
 Cela dit, les modules natifs sont également utilisables. Nous n’utilisons donc pas Webpack ici: vous pourrez le configurer plus tard.
 
-## Sommaire
+## Résumé
 
 Pour résumer, les concepts de base sont les suivants:
 

--- a/1-js/13-modules/02-import-export/article.md
+++ b/1-js/13-modules/02-import-export/article.md
@@ -325,7 +325,7 @@ auth/
         ...
 ```
 
-Nous aimerions exposer les fonctionnalités du paquet via un seul point d’entrée. 
+Nous aimerions exposer les fonctionnalités du paquet via un seul point d’entrée.
 
 En d'autres termes, une personne souhaitant utiliser notre package ne doit importer que depuis le "fichier principal" `auth/index.js`.
 
@@ -399,7 +399,7 @@ On peut y rencontrer deux problèmes :
 
 Ces bizarreries de réexporter une exportation par défaut sont l'une des raisons pour lesquelles certains développeurs n'aiment pas les exportations par défaut et préfèrent les exportations nommées.
 
-## Sommaire
+## Résumé
 
 Voici tous les types d'`export` que nous avons abordés dans ce chapitre et dans les chapitres précédents.
 
@@ -418,7 +418,7 @@ Import:
 
 - Importations d’exports nommés :
   - `import {x [as y], ...} from "module"`
-- Importation de l’export par défaut : 
+- Importation de l’export par défaut :
   - `import x from "module"`
   - `import {default as x} from "module"`
 - Tout importer :

--- a/1-js/13-modules/index.md
+++ b/1-js/13-modules/index.md
@@ -1,2 +1,1 @@
-
 # Modules

--- a/1-js/99-js-misc/01-proxy/article.md
+++ b/1-js/99-js-misc/01-proxy/article.md
@@ -342,7 +342,7 @@ Utilisons des proxys pour empêcher tout accès aux propriétés commençant par
 
 Nous aurons besoin des pièges:
 - `get` lancer une erreur lors de la lecture d'une telle propriété,
-- `set` lancer une erreur lors de l'écriture, 
+- `set` lancer une erreur lors de l'écriture,
 - `deleteProperty` lancer une erreur lors de la suppression,
 - `ownKeys` pour exclure les propriétés commençant par `_` de `for..in` et les méthodes comme `Object.keys`.
 
@@ -376,7 +376,7 @@ user = new Proxy(user, {
   },
 *!*
   deleteProperty(target, prop) { // pour intercepter la suppression de propriété
-*/!*  
+*/!*
     if (prop.startsWith('_')) {
       throw new Error("Access denied");
     } else {
@@ -998,7 +998,7 @@ Nous utilisons ici `WeakMap` au lieu de `Map` car cela ne bloquera pas le "garba
 - spécification: [Proxy](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots).
 - MDN: [Proxy](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Proxy).
 
-## Sommaire
+## Résumé
 
 Le `proxy` est un wrapper autour d'un objet, qui transfère des opérations sur celui-ci à l'objet, éventuellement en piégeant certains d'entre eux.
 

--- a/1-js/index.md
+++ b/1-js/index.md
@@ -1,6 +1,5 @@
-# JavaScript le language
+# JavaScript le langage
 
 Dans ce guide nous allons apprendre JavaScript, en partant de zéro jusqu'à des concepts avancés comme la POO.
 
 Nous allons nous concentrer ici sur le langage lui même, avec le minimum de notes spécifiques aux environnements.
-


### PR DESCRIPTION
Corrige plusieurs traductions de 'Summary' en 'Résumé' dans les fichiers suivants :
- 1-js/13-modules/01-modules-intro/article.md
- 1-js/13-modules/02-import-export/article.md
- 1-js/99-js-misc/01-proxy/article.md

Corrige la traduction de 'language' en 'langage' dans le fichier suivant :
- 1-js/index.md