### PR TITLE
Apporte plusieurs corrections au chapitre 1.10 (Gestion des erreurs)

### DIFF
--- a/1-js/10-error-handling/1-try-catch/1-finally-or-code-after/solution.md
+++ b/1-js/10-error-handling/1-try-catch/1-finally-or-code-after/solution.md
@@ -2,7 +2,7 @@ La différence devient évidente quand on regarde le code dans une fonction.
 
 Le comportement est différent s'il y a un "saut en dehors" de `try..catch`.
 
-Par exemple, quand il y a un `return` dans `try..catch`. La clause `finally` fonctionne en cas de *toute* sortie de` try..catch`, même via l'instruction `return` : juste après la fin de `try..catch`, mais avant que le code appelant obtienne le contrôle.
+Par exemple, quand il y a un `return` dans `try..catch`. La clause `finally` fonctionne en cas de *toute* sortie de `try..catch`, même via l'instruction `return` : juste après la fin de `try..catch`, mais avant que le code appelant obtienne le contrôle.
 
 ```js run
 function f() {
@@ -12,7 +12,7 @@ function f() {
     return "result";
 */!*
   } catch (err) {
-    /// ...
+    // ...
   } finally {
     alert('cleanup!');
   }
@@ -21,7 +21,7 @@ function f() {
 f(); // cleanup!
 ```
 
-...Ou quand il y a un `throw`, comme ici:
+...Ou quand il y a un `throw`, comme ici :
 
 ```js run
 function f() {

--- a/1-js/10-error-handling/1-try-catch/1-finally-or-code-after/task.md
+++ b/1-js/10-error-handling/1-try-catch/1-finally-or-code-after/task.md
@@ -2,7 +2,7 @@ importance: 5
 
 ---
 
-# Finally ou juste le code?
+# Finally ou juste le code ?
 
 Comparez les deux fragments de code.
 
@@ -19,6 +19,7 @@ Comparez les deux fragments de code.
     */!*
     }
     ```
+
 2. Le deuxième fragment fait le nettoyage juste après `try..catch` :
 
     ```js
@@ -35,4 +36,4 @@ Comparez les deux fragments de code.
 
 Nous avons absolument besoin du nettoyage après le travail, peu importe qu'il y ait une erreur ou non.
 
-Y at-il un avantage ici à utiliser `finally` ou les deux fragments de code sont égaux? Si un tel avantage existe, donnez un exemple lorsque cela compte.
+Y at-il un avantage ici à utiliser `finally` ou les deux fragments de code sont égaux ? Si un tel avantage existe, donnez un exemple lorsque cela compte.

--- a/1-js/10-error-handling/1-try-catch/article.md
+++ b/1-js/10-error-handling/1-try-catch/article.md
@@ -2,13 +2,13 @@
 
 Peu importe notre niveau en programmation, nos scripts comportent parfois des erreurs. Elles peuvent être dues à nos erreurs, à une entrée utilisateur imprévue, à une réponse erronée du serveur et à mille autres raisons.
 
-Généralement, un script "meurt" (s'arrête immédiatement) en cas d'erreur, en l'imprimant sur la console.
+Généralement, un script "meurt" (s'arrête immédiatement) en cas d'erreur, en l'affichant dans la console.
 
 Mais il existe une construction de syntaxe `try...catch` qui permet au script "d'attraper" les erreurs et, au lieu de mourir en cas de problème, de faire quelque chose de plus raisonnable.
 
 ## La syntaxe "try...catch"
 
-La construction `try...catch` a deux blocs principaux: `try`, puis `catch`:
+La construction `try...catch` a deux blocs principaux : `try`, puis `catch` :
 
 ```js
 try {
@@ -22,11 +22,11 @@ try {
 }
 ```
 
-Cela fonctionne comme ceci:
+Cela fonctionne comme ceci :
 
 1. Tout d'abord, le code dans `try {...}` est exécuté.
 2. S'il n'y a pas eu d'erreur, alors `catch(err)` est ignoré : l'exécution arrive à la fin de `try` et continue en ignorant `catch`.
-3. Si une erreur survient, alors l'exécution de `try` est arrêtée et le contrôle se place au début de `catch(err) `. La variable `err` (qui peut utiliser n'importe quel nom) contient un objet d'erreur avec des détails sur ce qui s'est passé.
+3. Si une erreur survient, alors l'exécution de `try` est arrêtée et le contrôle se place au début de `catch(err)`. La variable `err` (qui peut utiliser n'importe quel nom) contient un objet d'erreur avec des détails sur ce qui s'est passé.
 
 ![](try-catch-flow.svg)
 
@@ -34,7 +34,7 @@ Donc, une erreur dans le bloc `try {...}` ne tue pas le script -- nous avons une
 
 Voyons des exemples.
 
-- Un exemple sans erreur: affiche `alert` `(1)` et `(2)`:
+- Un exemple sans erreur : affiche `alert` `(1)` et `(2)` :
 
     ```js run
     try {
@@ -51,7 +51,8 @@ Voyons des exemples.
 
     }
     ```
-- Un exemple avec une erreur: montre `(1)` et `(3)`:
+
+- Un exemple avec une erreur : montre `(1)` et `(3)` :
 
     ```js run
     try {
@@ -71,7 +72,6 @@ Voyons des exemples.
     }
     ```
 
-
 ````warn header="`try...catch` ne fonctionne que pour les erreurs d'exécution"
 Pour que `try...catch` fonctionne, le code doit être exécutable. En d'autres termes, le code doit être du JavaScript valide.
 
@@ -89,7 +89,6 @@ Le moteur JavaScript lit d'abord le code, puis l'exécute. Les erreurs qui se pr
 
 Ainsi, `try...catch` ne peut gérer que les erreurs qui se produisent dans du code valide. De telles erreurs sont appelées "erreurs d'exécution" ou, parfois, "exceptions".
 ````
-
 
 ````warn header="`try...catch` fonctionne de manière synchrone"
 Si une exception se produit dans le code "planifié", comme dans `setTimeout`,`try...catch` ne l'attrapera pas :
@@ -109,7 +108,7 @@ C’est parce que la fonction elle-même est exécutée ultérieurement, lorsque
 Pour capturer une exception dans une fonction planifiée, `try...catch` doit être à l'intérieur de cette fonction :
 ```js run
 setTimeout(function() {
-  try {    
+  try {
     noSuchVariable; // try...catch gère l'erreur!
   } catch {
     alert( "error is caught here!" );

--- a/1-js/10-error-handling/1-try-catch/article.md
+++ b/1-js/10-error-handling/1-try-catch/article.md
@@ -75,7 +75,7 @@ Voyons des exemples.
 ````warn header="`try...catch` ne fonctionne que pour les erreurs d'exécution"
 Pour que `try...catch` fonctionne, le code doit être exécutable. En d'autres termes, le code doit être du JavaScript valide.
 
-Cela ne fonctionnera pas si le code est syntaxiquement incorrect, par exemple, il a des accolades inégalées:
+Cela ne fonctionnera pas si le code est syntaxiquement incorrect, par exemple, il a des accolades inégalées :
 
 ```js run
 try {
@@ -91,7 +91,7 @@ Ainsi, `try...catch` ne peut gérer que les erreurs qui se produisent dans du co
 ````
 
 ````warn header="`try...catch` fonctionne de manière synchrone"
-Si une exception se produit dans le code "planifié", comme dans `setTimeout`,`try...catch` ne l'attrapera pas :
+Si une exception se produit dans le code "planifié", comme dans `setTimeout`, `try...catch` ne l'attrapera pas :
 
 ```js run
 try {
@@ -109,7 +109,7 @@ Pour capturer une exception dans une fonction planifiée, `try...catch` doit êt
 ```js run
 setTimeout(function() {
   try {
-    noSuchVariable; // try...catch gère l'erreur!
+    noSuchVariable; // try...catch gère l'erreur !
   } catch {
     alert( "error is caught here!" );
   }
@@ -119,7 +119,7 @@ setTimeout(function() {
 
 ## Objet d'erreur
 
-En cas d'erreur, JavaScript génère un objet contenant les détails à son sujet. L'objet est ensuite passé en argument à `catch`:
+En cas d'erreur, JavaScript génère un objet contenant les détails à son sujet. L'objet est ensuite passé en argument à `catch` :
 
 ```js
 try {
@@ -129,7 +129,7 @@ try {
 }
 ```
 
-Pour toutes les erreurs intégrées, l'objet d'erreur a deux propriétés principales:
+Pour toutes les erreurs intégrées, l'objet d'erreur a deux propriétés principales :
 
 `name`
 : Nom de l'erreur. Par exemple, pour une variable non définie, il s'agit de `"ReferenceError"`.
@@ -137,12 +137,12 @@ Pour toutes les erreurs intégrées, l'objet d'erreur a deux propriétés princi
 `message`
 : Message textuel sur les détails de l'erreur.
 
-Il existe d'autres propriétés non standard disponibles dans la plupart des environnements. L'un des plus largement utilisés et supportés est:
+Il existe d'autres propriétés non standard disponibles dans la plupart des environnements. L'un des plus largement utilisés et supportés est :
 
 `stack`
-: Pile d'exécution en cours: chaîne contenant des informations sur la séquence d'appels imbriqués ayant entraîné l'erreur. Utilisé à des fins de débogage.
+: Pile d'exécution en cours : chaîne contenant des informations sur la séquence d'appels imbriqués ayant entraîné l'erreur. Utilisé à des fins de débogage.
 
-Par exemple:
+Par exemple :
 
 ```js run untrusted
 try {
@@ -164,7 +164,7 @@ try {
 
 [recent browser=new]
 
-Si nous n'avons pas besoin de détails d'erreur, `catch` peut l'omettre:
+Si nous n'avons pas besoin de détails d'erreur, `catch` peut l'omettre :
 
 ```js
 try {
@@ -182,7 +182,7 @@ Comme nous le savons déjà, JavaScript prend en charge la méthode [JSON.parse(
 
 Il est généralement utilisé pour décoder les données reçues sur le réseau, par le serveur ou par une autre source.
 
-Nous le recevons et appelons `JSON.parse` comme ceci:
+Nous le recevons et appelons `JSON.parse` comme ceci :
 
 ```js run
 let json = '{"name":"John", "age": 30}'; // données du serveur
@@ -200,7 +200,7 @@ Vous trouverez des informations plus détaillées sur JSON dans le chapitre <inf
 
 **Si `json` est malformé, `JSON.parse` génère une erreur, de sorte que le script "meurt".**
 
-Devrions-nous en être satisfaits ? Bien sûr que non!
+Devrions-nous en être satisfaits ? Bien sûr que non !
 
 De cette façon, si quelque chose ne va pas avec les données, le visiteur ne le saura jamais (à moins d'ouvrir la console du développeur). Et les gens n'aiment vraiment pas quand quelque chose "meurt" sans aucun message d'erreur.
 
@@ -226,13 +226,13 @@ try {
 }
 ```
 
-Ici, nous utilisons le bloc `catch` uniquement pour afficher le message, mais nous pouvons faire beaucoup plus: envoyer une nouvelle requête réseau, suggérer une alternative au visiteur, envoyer des informations sur l'erreur à un enregistrement des erreurs, ... . Bien mieux que de juste mourir.
+Ici, nous utilisons le bloc `catch` uniquement pour afficher le message, mais nous pouvons faire beaucoup plus : envoyer une nouvelle requête réseau, suggérer une alternative au visiteur, envoyer des informations sur l'erreur à un système de journalisation, ... Bien mieux que de juste mourir.
 
 ## Lever nos propres exceptions
 
-Que se passe-t-il si `json` est correct du point de vue syntaxique, mais qu'il n'a pas de propriété requise `name`?
+Que se passe-t-il si `json` est correct du point de vue syntaxique, mais qu'il n'a pas de propriété requise `name` ?
 
-Comme ceci:
+Comme ceci :
 
 ```js run
 let json = '{ "age": 30 }'; // données incomplètes
@@ -241,7 +241,7 @@ try {
 
   let user = JSON.parse(json); // <-- pas d'erreurs
 *!*
-  alert( user.name ); // pas de "name"!
+  alert( user.name ); // pas de "name" !
 */!*
 
 } catch (err) {
@@ -257,7 +257,7 @@ Pour unifier le traitement des erreurs, nous allons utiliser l'opérateur `throw
 
 L'instruction `throw` génère une erreur.
 
-La syntaxe est la suivante:
+La syntaxe est la suivante :
 
 ```js
 throw <error object>

--- a/1-js/10-error-handling/1-try-catch/article.md
+++ b/1-js/10-error-handling/1-try-catch/article.md
@@ -4,11 +4,11 @@ Peu importe notre niveau en programmation, nos scripts comportent parfois des er
 
 Généralement, un script "meurt" (s'arrête immédiatement) en cas d'erreur, en l'affichant dans la console.
 
-Mais il existe une construction de syntaxe `try...catch` qui permet au script "d'attraper" les erreurs et, au lieu de mourir en cas de problème, de faire quelque chose de plus raisonnable.
+Mais il existe une structure de syntaxe `try...catch` qui permet au script "d'attraper" les erreurs et, au lieu de mourir en cas de problème, de faire quelque chose de plus raisonnable.
 
 ## La syntaxe "try...catch"
 
-La construction `try...catch` a deux blocs principaux : `try`, puis `catch` :
+La structure `try...catch` a deux blocs principaux : `try`, puis `catch` :
 
 ```js
 try {
@@ -103,7 +103,7 @@ try {
 }
 ```
 
-C’est parce que la fonction elle-même est exécutée ultérieurement, lorsque le moteur a déjà quitté la construction `try...catch`.
+C’est parce que la fonction elle-même est exécutée ultérieurement, lorsque le moteur a déjà quitté la structure `try...catch`.
 
 Pour capturer une exception dans une fonction planifiée, `try...catch` doit être à l'intérieur de cette fonction :
 ```js run
@@ -561,7 +561,7 @@ alert( func() ); // en premier l'alert du `finally`, puis celle-ci (`1`)
 
 ````smart header="`try...finally`"
 
-La construction `try...finally`, sans la clause `catch`, est également utile. Nous l'appliquons lorsque nous ne voulons pas gérer les erreurs ici (les laisser passer), mais nous voulons être sûrs que les processus que nous avons démarrés sont finalisés.
+La structure `try...finally`, sans la clause `catch`, est également utile. Nous l'appliquons lorsque nous ne voulons pas gérer les erreurs ici (les laisser passer), mais nous voulons être sûrs que les processus que nous avons démarrés sont finalisés.
 
 ```js
 function func() {
@@ -576,19 +576,19 @@ function func() {
 Dans le code ci-dessus, une erreur à l'intérieur de `try` ressort toujours, car il n'y a pas de `catch`. Mais `finally` fonctionne avant que le flux d’exécution ne quitte la fonction.
 ````
 
-## Catch globale
+## Catch global
 
 ```warn header="Spécifique à l'environnement"
 Les informations de cette section ne font pas partie du code JavaScript principal.
 ```
 
-Imaginons que nous ayons une erreur fatale en dehors de `try...catch` et que le script soit mort. Comme une erreur de programmation ou autre chose terrible.
+Imaginons que nous ayons une erreur fatale en dehors de `try...catch` et que le script soit mort. Comme une erreur de programmation ou une autre chose terrible.
 
 Y a-t-il un moyen de réagir à de tels événements ? Nous pouvons vouloir enregistrer l'erreur, montrer quelque chose à l'utilisateur (normalement, ils ne voient pas les messages d'erreur), etc.
 
 Il n'y en a pas dans la spécification, mais les environnements le fournissent généralement, car c'est vraiment utile. Par exemple, Node.js a [`process.on("uncaughtException")`](https://nodejs.org/api/process.html#process_event_uncaughtexception) pour ça. Et dans le navigateur, nous pouvons attribuer une fonction à la propriété [window.onerror](https://developer.mozilla.org/fr/docs/Web/API/GlobalEventHandlers/onerror), qui fonctionnera en cas d'erreur non interceptée.
 
-La syntaxe:
+La syntaxe :
 
 ```js
 window.onerror = function(message, url, line, col, error) {
@@ -608,7 +608,7 @@ window.onerror = function(message, url, line, col, error) {
 `error`
 : Objet d'erreur.
 
-Par exemple:
+Par exemple :
 
 ```html run untrusted refresh height=1
 <script>
@@ -619,7 +619,7 @@ Par exemple:
 */!*
 
   function readData() {
-    badFunc(); // Whoops, quelque chose s'est mal passé!
+    badFunc(); // Whoops, quelque chose s'est mal passé !
   }
 
   readData();
@@ -628,9 +628,9 @@ Par exemple:
 
 Le rôle du gestionnaire global `window.onerror` est généralement de ne pas récupérer l'exécution du script - c'est probablement impossible en cas d'erreur de programmation, mais d'envoyer le message d'erreur aux développeurs.
 
-Il existe également des services Web fournissant un journal des erreurs pour de tels cas, comme<https://errorception.com> ou <https://www.muscula.com>.
+Il existe également des services Web fournissant un journal des erreurs pour de tels cas, comme <https://errorception.com> ou <https://www.muscula.com>.
 
-Ils fonctionnent comme ceci:
+Ils fonctionnent comme ceci :
 
 1. Nous nous inscrivons au service et obtenons un morceau de JS (ou une URL de script) à insérer sur des pages.
 2. Ce script JS définit une fonction `window.onerror` personnalisée.
@@ -639,9 +639,9 @@ Ils fonctionnent comme ceci:
 
 ## Résumé
 
-La construction `try...catch` permet de gérer les erreurs d'exécution. Cela permet littéralement "d'essayer" (`try`) d'exécuter le code et "d’attraper" (`catch`) les erreurs qui peuvent s'y produire.
+La structure `try...catch` permet de gérer les erreurs d'exécution. Cela permet littéralement "d'essayer" (`try`) d'exécuter le code et "d’attraper" (`catch`) les erreurs qui peuvent s'y produire.
 
-La syntaxe est la suivante:
+La syntaxe est la suivante :
 
 ```js
 try {
@@ -654,18 +654,18 @@ try {
 }
 ```
 
-Il peut ne pas y avoir de section `catch` ou de `finally`, donc les constructions plus courtes `try...catch` et `try...finally` sont également valides.
+Il peut ne pas y avoir de section `catch` ou de `finally`, donc les structures plus courtes `try...catch` et `try...finally` sont également valides.
 
-Les objets d'erreur ont les propriétés suivantes:
+Les objets d'erreur ont les propriétés suivantes :
 
 - `message` - le message d'erreur.
 - `name` - la chaîne avec le nom d'erreur (nom du constructeur de l'erreur).
 - `stack` (non standard, mais bien supporté) - la pile d'exécution au moment de la création de l'erreur.
 
-Si un objet d'erreur n'est pas nécessaire, nous pouvons l'omettre en utilisant `catch {` au lieu de `catch(err) {`.
+Si un objet d'erreur n'est pas nécessaire, nous pouvons l'omettre en utilisant `catch {...}` au lieu de `catch(err) {...}`.
 
 Nous pouvons également générer nos propres erreurs en utilisant l'opérateur `throw`. Techniquement, l'argument de `throw` peut être n'importe quoi, mais il s'agit généralement d'un objet d'erreur héritant de la classe `Error` intégrée. Plus d'informations sur l'extension des erreurs dans le chapitre suivant.
 
-La technique de *propagation* est un modèle très important de gestion des erreurs: un bloc `catch` s'attend généralement à savoir comment gérer le type d'erreur particulier et sait comment le gérer. Il doit donc "propager" les erreurs qu'il ne connaît pas.
+La technique de *propagation* est un modèle très important de gestion des erreurs : un bloc `catch` s'attend généralement à un type d'erreur particulier et sait comment le gérer, il doit donc "propager" (renvoyer) les erreurs qu'il ne connaît pas.
 
-Même si nous n'avons pas `try...catch`, la plupart des environnements permettent de configurer un gestionnaire d'erreurs "globale" pour intercepter les erreurs qui "tombent". Dans le navigateur, c'est `window.onerror`.
+Même si nous n'avons pas `try...catch`, la plupart des environnements permettent de configurer un gestionnaire d'erreurs "globales" pour intercepter les erreurs qui "tombent". Dans le navigateur, c'est `window.onerror`.

--- a/1-js/10-error-handling/1-try-catch/article.md
+++ b/1-js/10-error-handling/1-try-catch/article.md
@@ -265,9 +265,9 @@ throw <error object>
 
 Techniquement, on peut utiliser n'importe quoi comme objet d'erreur. Cela peut même être une primitive, comme un nombre ou une chaîne, mais il est préférable d’utiliser des objets, de préférence avec les propriétés `name` et `message` (pour rester quelque peu compatibles avec les erreurs intégrées).
 
-JavaScript comporte de nombreux constructeurs intégrés pour les erreurs standard: `Error`, `SyntaxError`, `ReferenceError`, `TypeError` et autres. Nous pouvons également les utiliser pour créer des objets d'erreur.
+JavaScript comporte de nombreux constructeurs intégrés pour les erreurs standards : `Error`, `SyntaxError`, `ReferenceError`, `TypeError` et autres. Nous pouvons également les utiliser pour créer des objets d'erreur.
 
-Leur syntaxe est la suivante:
+Leur syntaxe est la suivante :
 
 ```js
 let error = new Error(message);
@@ -279,7 +279,7 @@ let error = new ReferenceError(message);
 
 Pour les erreurs intégrées (pas pour les objets, mais pour les erreurs), la propriété `name` est exactement le nom du constructeur. Et `message` est tiré de l'argument.
 
-Par exemple:
+Par exemple :
 
 ```js run
 let error = new Error("Things happen o_O");
@@ -288,7 +288,7 @@ alert(error.name); // Error
 alert(error.message); // Things happen o_O
 ```
 
-Voyons quel type d'erreur `JSON.parse` génère:
+Voyons quel type d'erreur `JSON.parse` génère :
 
 ```js run
 try {
@@ -303,9 +303,9 @@ try {
 
 Comme on peut le constater, c’est une `SyntaxError`.
 
-Et dans notre cas, l’absence de `name` est une erreur, car les utilisateurs doivent avoir un` name`.
+Et dans notre cas, l’absence de `name` est une erreur, car les utilisateurs doivent avoir un `name`.
 
-Alors utilisons throw:
+Alors utilisons `throw` :
 
 ```js run
 let json = '{ "age": 30 }'; // données incomplètes
@@ -327,9 +327,9 @@ try {
 }
 ```
 
-Dans la ligne `(*)`, l'instruction `throw` génère une `SyntaxError` avec le `message` donné, de la même manière que JavaScript le générerait lui-même. L'exécution de `try` s'arrête immédiatement et le flux de contrôle saute dans `catch`.
+À la ligne `(*)`, l'instruction `throw` génère une `SyntaxError` avec le `message` donné, de la même manière que JavaScript le générerait lui-même. L'exécution de `try` s'arrête immédiatement et le flux de contrôle saute dans `catch`.
 
-Maintenant, `catch` est devenu un emplacement unique pour toutes les erreurs de traitement: à la fois pour `JSON.parse` et d'autres cas.
+Maintenant, `catch` est devenu un emplacement unique pour toutes les erreurs de traitement : à la fois pour `JSON.parse` et d'autres cas.
 
 ## Propager une exception
 
@@ -350,7 +350,7 @@ try {
 }
 ```
 
-Bien sûr, tout est possible! Les programmeurs font des erreurs. Même dans les utilitaires à code source ouvert utilisés par des millions de personnes pendant des décennies, on découvre soudainement un bug qui conduit à de terribles piratages.
+Bien sûr, tout est possible ! Les programmeurs font des erreurs. Même dans les utilitaires à code source ouvert utilisés par des millions de personnes pendant des décennies, on découvre soudainement un bug qui conduit à de terribles piratages.
 
 Dans notre cas, `try...catch` est destiné à intercepter les erreurs "incorrect data". Mais par sa nature, `catch` obtient *toutes* les erreurs de `try`. Ici, une erreur inattendue se produit, mais le même message `"JSON Error"` est toujours affiché. C'est faux et rend également le code plus difficile à déboguer.
 
@@ -373,14 +373,14 @@ try {
 *!*
   if (err instanceof ReferenceError) {
 */!*
-    alert('ReferenceError'); // "ReferenceError" for accessing an undefined variable
+    alert('ReferenceError'); // "ReferenceError" pour avoir accédé à une variable non définie
   }
 }
 ```
 
 Nous pouvons également obtenir le nom de la classe d'erreur à partir de la propriété `err.name`. Toutes les erreurs natives l'ont. Une autre option est de lire `err.constructor.name`.
 
-Dans le code ci-dessous, nous utilisons la technique de "propagation" pour que `catch` ne traite que `SyntaxError`:
+Dans le code ci-dessous, nous utilisons la technique de "propagation" pour que `catch` ne traite que `SyntaxError` :
 
 ```js run
 let json = '{ "age": 30 }'; // données incomplètes
@@ -411,11 +411,11 @@ try {
 }
 ```
 
-L’erreur de l’instruction throw à la ligne `(*)` de l’intérieur du bloc `catch` "tombe" de `try...catch` et peut être interceptée par une construction externe `try...catch` (si elle existe), ou tue le script.
+L’erreur de l’instruction `throw` à la ligne `(*)` de l’intérieur du bloc `catch` "sort" de `try...catch` et peut être soit capturée par une structure `try...catch` externe (si elle existe), soit elle arrête le script.
 
-Ainsi, le bloc `catch` ne traite que les erreurs qu’il sait gérer et" ignore "toutes les autres.
+Ainsi, le bloc `catch` ne traite que les erreurs qu’il sait gérer et "ignore" toutes les autres.
 
-L'exemple ci-dessous montre comment de telles erreurs peuvent être interceptées par un niveau supplémentaire de `try...catch` :
+L'exemple ci-dessous montre comment de telles erreurs peuvent être capturées par un niveau supplémentaire de `try...catch` :
 
 ```js run
 function readData() {
@@ -430,7 +430,7 @@ function readData() {
     // ...
     if (!(err instanceof SyntaxError)) {
 *!*
-      throw err; // propager (ne sachant pas comment gérer)
+      throw err; // propager l'erreur (ne sachant pas comment la gérer)
 */!*
     }
   }
@@ -440,7 +440,7 @@ try {
   readData();
 } catch (err) {
 *!*
-  alert( "External catch got: " + err ); // attrapé!
+  alert( "External catch got: " + err ); // attrapé !
 */!*
 }
 ```
@@ -449,16 +449,16 @@ Ici, `readData` ne sait que gérer `SyntaxError`, alors que le `try...catch` ext
 
 ## try...catch...finally
 
-Attends, ce n'est pas tout.
+Mais ce n'est pas tout.
 
-La construction `try...catch` peut avoir une autre clause de code : `finally`.
+La structure `try...catch` peut avoir un bloc de code supplémentaire : `finally`.
 
-S'il existe, il s'exécute dans tous les cas:
+S'il existe, il s'exécute dans tous les cas :
 
 - après `try`, s'il n'y a pas eu d'erreur,
 - après `catch`, s'il y a eu des erreurs.
 
-La syntaxe étendue ressemble à ceci:
+La syntaxe étendue ressemble à ceci :
 
 ```js
 *!*try*/!* {
@@ -470,7 +470,7 @@ La syntaxe étendue ressemble à ceci:
 }
 ```
 
-Essayez d'exécuter ce code:
+Essayez d'exécuter ce code :
 
 ```js run
 try {
@@ -483,7 +483,7 @@ try {
 }
 ```
 
-Le code a deux manières d'exécution:
+Ce code a deux manières de s'exécuter :
 
 1. Si vous répondez "Yes" à "Make an error?", Alors `try -> catch -> finally`.
 2. Si vous dites "No", alors `try -> finally`.

--- a/1-js/10-error-handling/1-try-catch/article.md
+++ b/1-js/10-error-handling/1-try-catch/article.md
@@ -579,7 +579,7 @@ Dans le code ci-dessus, une erreur à l'intérieur de `try` ressort toujours, ca
 ## Catch global
 
 ```warn header="Spécifique à l'environnement"
-Les informations de cette section ne font pas partie du code JavaScript principal.
+Les informations de cette section ne font pas partie du JavaScript de base.
 ```
 
 Imaginons que nous ayons une erreur fatale en dehors de `try...catch` et que le script soit mort. Comme une erreur de programmation ou une autre chose terrible.

--- a/1-js/10-error-handling/1-try-catch/article.md
+++ b/1-js/10-error-handling/1-try-catch/article.md
@@ -488,16 +488,16 @@ Ce code a deux manières de s'exécuter :
 1. Si vous répondez "Yes" à "Make an error?", Alors `try -> catch -> finally`.
 2. Si vous dites "No", alors `try -> finally`.
 
-La clause `finally` est souvent utilisée lorsque nous commençons à faire quelque chose et que nous voulons le finaliser dans tous les cas de résultats.
+La clause `finally` est souvent utilisée lorsque nous commençons à faire quelque chose et que nous voulons le finaliser dans tous les cas de figure.
 
-Par exemple, nous voulons mesurer le temps que prend une fonction de nombre de Fibonacci `fib(n)`. Naturellement, nous pouvons commencer à mesurer avant l'exécution et finir ensuite. Mais que se passe-t-il s'il y a une erreur lors de l'appel de la fonction? En particulier, la mise en oeuvre de `fib(n)` dans le code ci-dessous renvoie une erreur pour les nombres négatifs ou non entiers.
+Par exemple, nous voulons mesurer le temps que prend une fonction de nombre de Fibonacci `fib(n)`. Naturellement, nous pouvons commencer à mesurer avant l'exécution et finir ensuite. Mais que se passe-t-il s'il y a une erreur lors de l'appel de la fonction ? En particulier, la mise en oeuvre de `fib(n)` dans le code ci-dessous renvoie une erreur pour les nombres négatifs ou non entiers.
 
 La clause `finally` est un bon endroit pour finir les mesures, quoi qu’il arrive.
 
-Ici, `finally` garantit que le temps sera correctement mesuré dans les deux situations - en cas d’exécution réussie de `fib` et en cas d’erreur:
+Ici, `finally` garantit que le temps sera correctement mesuré dans les deux situations - en cas d’exécution réussie de `fib` et en cas d’erreur :
 
 ```js run
-let num = +prompt("Enter a positive integer number?", 35)
+let num = +prompt("Enter a positive integer number.", 35)
 
 let diff, result;
 
@@ -529,7 +529,6 @@ Vous pouvez vérifier en exécutant le code en entrant `35` dans `prompt` - il s
 
 En d'autres termes, la fonction peut finir par `return` ou `throw`, cela n'a pas d'importance. La clause `finally` s'exécute dans les deux cas.
 
-
 ```smart header="Les variables sont locales à l'intérieur de `try...catch...finally`"
 Veuillez noter que les variables `result` et `diff` dans le code ci-dessus sont déclarées *avant* `try...catch`.
 
@@ -543,12 +542,10 @@ Dans l'exemple ci-dessous, il y a `return` dans `try`. Dans ce cas, `finally` es
 
 ```js run
 function func() {
-
   try {
 *!*
     return 1;
 */!*
-
   } catch (err) {
     /* ... */
   } finally {
@@ -558,13 +555,13 @@ function func() {
   }
 }
 
-alert( func() ); // en premièr l'alert du `finally`, puis celle-ci
+alert( func() ); // en premier l'alert du `finally`, puis celle-ci (`1`)
 ```
 ````
 
 ````smart header="`try...finally`"
 
-La construction `try...finally`, sans la clause `catch`, est également utile. Nous l'appliquons lorsque nous ne voulons pas gérer les erreurs ici (laissez-les tomber), mais nous voulons être sûrs que les processus que nous avons démarrés sont finalisés.
+La construction `try...finally`, sans la clause `catch`, est également utile. Nous l'appliquons lorsque nous ne voulons pas gérer les erreurs ici (les laisser passer), mais nous voulons être sûrs que les processus que nous avons démarrés sont finalisés.
 
 ```js
 function func() {
@@ -576,7 +573,7 @@ function func() {
   }
 }
 ```
-Dans le code ci-dessus, une erreur à l'intérieur de `try` tombe toujours, car il n'y a pas de `catch`. Mais `finally` fonctionne avant que le flux d’exécution ne quitte la fonction.
+Dans le code ci-dessus, une erreur à l'intérieur de `try` ressort toujours, car il n'y a pas de `catch`. Mais `finally` fonctionne avant que le flux d’exécution ne quitte la fonction.
 ````
 
 ## Catch globale

--- a/1-js/10-error-handling/2-custom-errors/1-format-error/task.md
+++ b/1-js/10-error-handling/2-custom-errors/1-format-error/task.md
@@ -8,7 +8,7 @@ Créez une classe `FormatError` qui hérite de la classe `SyntaxError` intégré
 
 Il devrait supporter les propriétés `message`, `name` et `stack`.
 
-Exemple d'utilisation:
+Exemple d'utilisation :
 
 ```js
 let err = new FormatError("formatting error");

--- a/1-js/10-error-handling/2-custom-errors/article.md
+++ b/1-js/10-error-handling/2-custom-errors/article.md
@@ -1,8 +1,8 @@
-# Les erreurs personnalisées, Étendre Error
+# Les erreurs personnalisées, extension de Error
 
 Lorsque nous développons quelque chose, nous avons souvent besoin de nos propres classes d'erreur pour refléter des problèmes spécifiques qui peuvent mal tourner dans nos tâches. Pour les erreurs dans les opérations réseau, nous aurons peut-être besoin de `HttpError`, pour les opérations de base de données `DbError`, pour les opérations de recherche `NotFoundError`, etc.
 
-Nos erreurs devraient prendre en charge des propriétés d'erreur de base telles que `message`, `name` et, de préférence, `stack`. Mais elles peuvent aussi avoir d’autres propriétés propres, par exemple Les objets `HttpError` peuvent avoir une propriété `statusCode` avec une valeur telle que `404` ou `403` ou `500`.
+Nos erreurs devraient prendre en charge des propriétés d'erreur de base telles que `message`, `name` et, de préférence, `stack`. Mais elles peuvent aussi avoir d’autres propriétés propres, par exemple les objets `HttpError` peuvent avoir une propriété `statusCode` avec une valeur telle que `404` ou `403` ou `500`.
 
 JavaScript permet d'utiliser `throw` avec n'importe quel argument. Par conséquent, techniquement, nos classes d'erreur personnalisées n'ont pas besoin d'hériter de `Error`. Mais si nous héritons, il devient alors possible d'utiliser `obj instanceof Error` pour identifier les objets d'erreur. Il vaut donc mieux en hériter.
 
@@ -12,12 +12,13 @@ Au fur et à mesure que l'application grandit, nos propres erreurs forment natur
 
 A titre d'exemple, considérons une fonction `readUser(json)` qui devrait lire JSON avec des données utilisateur.
 
-Voici un exemple de l'apparence d'un `json` valide:
+Voici un exemple de l'apparence d'un `json` valide :
+
 ```js
 let json = `{ "name": "John", "age": 30 }`;
 ```
 
-En interne, nous utiliserons `JSON.parse`. S'il reçoit un `json` malformé, il renvoie` SyntaxError`. Mais même si `json` est syntaxiquement correct, cela ne signifie pas que c'est un utilisateur valide, non? Il peut manquer les données nécessaires. Par exemple, il peut ne pas avoir les propriétés `name` et `age` qui sont essentielles pour nos utilisateurs.
+En interne, nous utiliserons `JSON.parse`. S'il reçoit un `json` malformé, il renvoie `SyntaxError`. Mais même si `json` est syntaxiquement correct, cela ne signifie pas que c'est un utilisateur valide, non ? Il peut manquer les données nécessaires. Par exemple, il peut ne pas avoir les propriétés `name` et `age` qui sont essentielles pour nos utilisateurs.
 
 Notre fonction `readUser(json)` va non seulement lire JSON, mais aussi vérifier ("valider") les données. S'il n'y a pas de champs obligatoires ou si le format est incorrect, c'est une erreur. Et ce n’est pas une `SyntaxError`, car les données sont syntaxiquement correctes, mais un autre type d’erreur. Nous l'appellerons `ValidationError` et créerons une classe pour cela. Une erreur de ce type devrait également comporter des informations sur le champ fautif.
 
@@ -36,7 +37,7 @@ class Error {
 }
 ```
 
-Maintenant, héritons de `ValidationError` et mettons-le en action:
+Maintenant, héritons de `ValidationError` et mettons-le en action :
 
 ```js run untrusted
 *!*
@@ -57,15 +58,15 @@ try {
 } catch(err) {
   alert(err.message); // Whoops!
   alert(err.name); // ValidationError
-  alert(err.stack); // une liste des appels imbriqués avec des numéros de ligne pour chaque
+  alert(err.stack); // une liste des appels imbriqués avec le numéro de ligne pour chacun d'entre eux
 }
 ```
 
-Remarque: à la ligne `(1)`, nous appelons le constructeur parent. JavaScript exige que nous appelions `super` dans le constructeur de l'enfant, donc c'est obligatoire. Le constructeur parent définit la propriété `message`.
+Remarque : à la ligne `(1)`, nous appelons le constructeur parent. JavaScript exige que nous appelions `super` dans le constructeur de l'enfant, donc c'est obligatoire. Le constructeur parent définit la propriété `message`.
 
 Le constructeur parent définit également la propriété `name` sur `"Error"`, donc à la ligne `(2)` nous la réinitialisons à la valeur correcte.
 
-Essayons de l'utiliser dans `readUser(json)`:
+Essayons de l'utiliser dans `readUser(json)` :
 
 ```js run
 class ValidationError extends Error {
@@ -101,7 +102,7 @@ try {
   } else if (err instanceof SyntaxError) { // (*)
     alert("JSON Syntax Error: " + err.message);
   } else {
-    throw err; // erreur inconnue, propager le (**)
+    throw err; // erreur inconnue, on la propage (**)
   }
 }
 ```
@@ -110,7 +111,7 @@ Le bloc `try..catch` dans le code ci-dessus gère à la fois notre `ValidationEr
 
 Veuillez regarder comment nous utilisons `instanceof` pour vérifier le type d'erreur spécifique à la ligne `(*)`.
 
-Nous pourrions aussi regarder `err.name`, comme ceci:
+Nous pourrions aussi regarder `err.name`, comme ceci :
 
 ```js
 // ...
@@ -119,9 +120,9 @@ Nous pourrions aussi regarder `err.name`, comme ceci:
 // ...
 ```
 
-La version `instanceof` est bien meilleure, car dans le futur nous allons étendre `ValidationError`, en créer des sous-types, comme `PropertyRequiredError`. Et `instanceof` check continuera à fonctionner pour les nouvelles classes héritées. Donc, c'est à l'épreuve du futur.
+La version `instanceof` est bien meilleure, car dans le futur nous allons étendre `ValidationError`, en créer des sous-types, comme `PropertyRequiredError`. Et `instanceof` continuera à fonctionner pour les nouvelles classes héritées. Donc, c'est à l'épreuve du futur.
 
-Il est également important que si `catch` rencontre une erreur inconnue, il la renvoie dans la ligne `(**)`. Le bloc `catch` ne sait que gérer les erreurs de validation et de syntaxe, d'autres types (causés par une faute de frappe dans le code ou d'autres raisons inconnues) devraient tomber.
+Il est également important que si `catch` rencontre une erreur inconnue, il la renvoie à la ligne `(**)`. Le bloc `catch` ne sait gérer que les erreurs de validation et de syntaxe, les autres types (causés par une faute de frappe dans le code ou d'autres raisons inconnues) devraient êtres propagés.
 
 ## Héritage complémentaire
 
@@ -173,18 +174,18 @@ try {
   } else if (err instanceof SyntaxError) {
     alert("JSON Syntax Error: " + err.message);
   } else {
-    throw err; // erreur inconnue, propager le
+    throw err; // erreur inconnue, on la propage
   }
 }
 ```
 
-La nouvelle classe `PropertyRequiredError` est facile à utiliser: il suffit de passer le nom de la propriété: `new PropertyRequiredError(property)`. Le `message` est généré par le constructeur.
+La nouvelle classe `PropertyRequiredError` est facile à utiliser : il suffit de passer le nom de la propriété : `new PropertyRequiredError(property)`. Le `message` est généré par le constructeur.
 
-Veuillez noter que `this.name` dans le constructeur `PropertyRequiredError` est à nouveau attribué manuellement. Cela peut devenir un peu fastidieux -- d'assigner `this.name = <class name>` dans chaque classe d'erreur personnalisée. Nous pouvons l'éviter en créant notre propre classe "d'erreur de base" qui assigne `this.name = this.constructor.name`. Et puis hériter de toutes nos erreurs personnalisées.
+Veuillez noter que `this.name` dans le constructeur `PropertyRequiredError` est à nouveau attribué manuellement. Cela peut devenir un peu fastidieux -- d'assigner `this.name = <class name>` dans chaque classe d'erreur personnalisée. Nous pouvons l'éviter en créant notre propre classe "d'erreur de base" qui assigne `this.name = this.constructor.name`. Puis nous en ferons hériter toutes nos classes d'erreur personnalisées.
 
 Appelons cela `MyError`.
 
-Voici le code avec `MyError` et d'autres classes d'erreur personnalisées, simplifié:
+Voici le code avec `MyError` et d'autres classes d'erreur personnalisées, simplifié :
 
 ```js run
 class MyError extends Error {
@@ -205,7 +206,7 @@ class PropertyRequiredError extends ValidationError {
   }
 }
 
-// name is correct
+// le nom est correcte
 alert( new PropertyRequiredError("field").name ); // PropertyRequiredError
 ```
 
@@ -247,9 +248,9 @@ La technique que nous décrivons ici est appelée "encapsulation d'exceptions".
 2. La fonction `readUser` interceptera les erreurs de lecture de données qui se produisent à l'intérieur, telles que `ValidationError` et `SyntaxError`, et générera à la place une `ReadError`.
 3. L'objet `ReadError` conservera la référence à l'erreur d'origine dans sa propriété `cause`.
 
-Ensuite, le code qui appelle `readUser` n'aura qu'à vérifier` ReadError`, pas pour tous les types d'erreurs de lecture de données. Et s'il a besoin de plus de détails sur une erreur, il peut vérifier sa propriété `cause`.
+Ensuite, le code qui appelle `readUser` n'aura qu'à vérifier `ReadError`, pas pour tous les types d'erreurs de lecture de données. Et s'il a besoin de plus de détails sur une erreur, il peut vérifier sa propriété `cause`.
 
-Voici le code qui définit `ReadError` et illustre son utilisation dans `readUser` et `try..catch`:
+Voici le code qui définit `ReadError` et illustre son utilisation dans `readUser` et `try..catch` :
 
 ```js run
 class ReadError extends Error {
@@ -317,7 +318,7 @@ try {
 }
 ```
 
-Dans le code ci-dessus, `readUser` fonctionne exactement comme décrit ci-dessus - corrige les erreurs de syntaxe et de validation et "throw" les erreurs `ReadError` (les erreurs inconnues sont propagées comme d'habitude).
+Dans le code ci-dessus, `readUser` fonctionne exactement comme décrit - il intercepte les erreurs de syntaxe et de validation et propage des erreurs `ReadError` (les erreurs inconnues sont propagées comme d'habitude).
 
 Donc, le code externe vérifie `instanceof ReadError` et c'est tout. Pas besoin de lister tous les types d'erreur possibles.
 


### PR DESCRIPTION
Apporte diverses corrections et améliorations mineures au chapitre "1-js/10-error-handling".

Dans la partie "Catch global", pour le texte du message d'avertissement "Spécifique à l'environnement", je ne suis pas sûr que ma correction soit optimale :

Original (anglais) : "The information from this section is not a part of the core JavaScript."
Original (français) : "Les informations de cette section ne font pas partie du code JavaScript principal."
Proposition : "Les informations de cette section ne font pas partie du JavaScript de base."

Est-ce que traduire "_core JavaScript_" par "_JavaScript de base_" vous semble correct ?