### PR TITLE
Corrige le terme 'language' en 'langage'

### DIFF
--- a/1-js/01-getting-started/1-intro/article.md
+++ b/1-js/01-getting-started/1-intro/article.md
@@ -15,7 +15,7 @@ Les scripts sont fournis et exécutés en texte brut. Ils n'ont pas besoin d'une
 De par cet aspect, JavaScript est très différent d'un autre langage appelé [Java](<https://fr.wikipedia.org/wiki/Java_(langage)>).
 
 ```smart header="Pourquoi est-il appelé <u>Java</u>Script ?"
-Quand Javascript a été créé, il portait initialement un autre nom : "LiveScript". Mais à cette époque le langage Java était très populaire, il a donc été décidé que positionner un nouveau langage en tant que "petit frère" de Java pourrait aider.
+Quand JavaScript a été créé, il portait initialement un autre nom : "LiveScript". Mais à cette époque le langage Java était très populaire, il a donc été décidé que positionner un nouveau langage en tant que "petit frère" de Java pourrait aider.
 
 Mais au fur et à mesure de son évolution, JavaScript est devenu un langage totalement indépendant, avec ses propres spécifications appelées [ECMAScript](https://fr.wikipedia.org/wiki/ECMAScript), aujourd'hui il n'a aucun rapport avec Java.
 ```

--- a/1-js/01-getting-started/index.md
+++ b/1-js/01-getting-started/index.md
@@ -1,3 +1,3 @@
 # Une introduction
 
-A propos du langage Javascript et de l'environnement pour le développeur.
+A propos du langage JavaScript et de l'environnement pour le développeur.

--- a/1-js/02-first-steps/01-hello-world/article.md
+++ b/1-js/02-first-steps/01-hello-world/article.md
@@ -1,15 +1,15 @@
 # Hello, world!
- 
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/0WS0zqhT5fM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Cette partie du tutoriel est à propos du coeur de JavaScript, le langage lui même. 
+Cette partie du tutoriel est à propos du coeur de JavaScript, le langage lui même.
 
 Mais nous avons besoin d'un environnement de travail pour exécuter nos scripts et, étant donné que ce guide est en ligne, le navigateur est un bon choix. Nous allons nous efforcer d'utiliser les commandes spécifiques au navigateur (comme `alert`) au minimum afin de ne pas y consacrer du temps si vous prévoyez de vous concentrer sur un autre environnement tel que Node.JS. Par ailleurs, les détails du navigateur sont expliqués dans [la partie suivante](/ui) du didacticiel.
 
 Alors, voyons d'abord comment intégrer un script à une page Web. Pour les environnements côté serveur, vous pouvez simplement l'exécuter avec une commande comme `"node mon.js"` pour Node.JS.
 
 
-## La balise "script" 
+## La balise "script"
 
 Les programmes JavaScript peuvent être insérés dans n'importe quelle partie d'un document HTML à l'aide de la balise `<script>`.
 
@@ -50,9 +50,8 @@ La balise `<script>` a quelques attributs qui sont rarement utilisés de nos jou
  L'attribut `type` : <code>&lt;script <u>type</u>=...&gt;</code>
 : L’ancien standard HTML4, nécessitait pour chaque script d'avoir un `type`. Habiutellement c'était `type="text/javascript"`. Dorénavant ce n’est plus nécessaire. De plus, le standard HTML moderne a totalement changé la signification de cet attribut. Maintenant, il peut être utilisé pour les modules JavaScript. Mais c’est un sujet avancé, nous parlerons de modules dans une autre partie du tutoriel.
 
-
  L'attribut `language` : <code>&lt;script <u>language</u>=...&gt;</code>
-: Cet attribut était destiné à afficher la langue du script. Pour l'instant, cet attribut n'a aucun sens, le langage est le JavaScript par défaut. Pas besoin de l'utiliser.
+: Cet attribut était destiné à afficher le langage du script. Pour l'instant, cet attribut n'a aucun sens, le langage est le JavaScript par défaut. Pas besoin de l'utiliser.
 
 Commentaires avant et après les scripts.
 : Dans des livres et des guides vraiment anciens, on peut trouver des commentaires dans `<script>`, comme ceci :

--- a/1-js/02-first-steps/05-types/article.md
+++ b/1-js/02-first-steps/05-types/article.md
@@ -41,6 +41,7 @@ Outre les nombres réguliers, il existe des "valeurs numériques spéciales" qui
     ```js run
     alert( Infinity ); // Infinity
     ```
+
 - `NaN` représente une erreur de calcul. C'est le résultat d'une opération mathématique incorrecte ou non définie, par exemple :
 
     ```js run
@@ -56,7 +57,6 @@ Outre les nombres réguliers, il existe des "valeurs numériques spéciales" qui
     ```
 
     Donc, s'il y a `NaN` quelque part dans une expression mathématique, il se propage à l'ensemble du résultat (il n'y a qu'une seule exception : `NaN ** 0` vaut `1`).
-
 
 ```smart header="Les opérations mathématiques sont sûres"
 Faire des maths est sans danger en JavaScript. Nous pouvons faire n'importe quoi : diviser par zéro, traiter les chaînes non numériques comme des nombres, etc.
@@ -228,7 +228,6 @@ Le type `symbol` est utilisé pour créer des identificateurs uniques pour les o
 
 L'opérateur `typeof` renvoie le type de l'argument. Il est utile lorsqu'on souhaite traiter différemment les valeurs de différents types ou de faire une vérification rapide.
 
-
 L'appel `typeof x` renvoie une chaîne de caractères avec le nom du type :
 
 ```js
@@ -262,8 +261,6 @@ Les trois dernières lignes peuvent nécessiter des explications supplémentaire
 1. `Math` est un objet interne au langage qui fournit des opérations mathématiques. Nous allons l'apprendre dans le chapitre <info:number>. Ici, il sert uniquement comme exemple d'un objet.
 2. Le résultat de `typeof null` est `"object"`. C'est une erreur officiellement reconnue dans `typeof`, datant des premiers jours de JavaScript et conservée pour compatibilité. Bien sûr, `null` n'est pas un objet. C'est une valeur spéciale avec un type distinct qui lui est propre. Le comportement de `typeof` est incorrect ici.
 3. Le résultat de `typeof alert` est `"function"`, car `alert` est une fonction. Nous étudierons les fonctions dans les chapitres suivants, et nous verrons qu’il n’y a pas de type "fonction" en JavaScript. Les fonctions appartiennent au type `object`. Mais `typeof` les traite différemment, en retournant `"fonction"`. Cela vient également des débuts de JavaScript. Techniquement ce n’est pas tout à fait correct, mais très pratique à l'usage.
-
-
 
 ```smart header="La syntaxe `typeof(x)`"
 Vous pouvez également rencontrer une autre syntaxe : `typeof(x)`. C'est la même chose que `typeof x`.

--- a/1-js/02-first-steps/05-types/article.md
+++ b/1-js/02-first-steps/05-types/article.md
@@ -135,6 +135,7 @@ alert( `the result is *!*${1 + 2}*/!*` ); // le résultat est 3
 L'expression à l'intérieur de `${…}` est évaluée et le résultat devient une partie de la chaîne. On peut y mettre n'importe quoi : une variable comme `name` ou une expression arithmétique comme `1 + 2` ou quelque chose de plus complexe.
 
 Veuillez noter que cela ne peut être fait que dans les backticks. Les autres guillemets ne permettent pas une telle intégration !
+
 ```js run
 alert( "the result is ${1 + 2}" ); // le résultat est ${1 + 2} (les doubles quotes ne font rien)
 ```
@@ -142,7 +143,7 @@ alert( "the result is ${1 + 2}" ); // le résultat est ${1 + 2} (les doubles quo
 Nous couvrirons les chaînes de caractères plus en détails dans le chapitre <info:string>.
 
 ```smart header="Il n'y a pas de type *character*."
-Dans certaines langues, il existe un type spécial "character" pour un seul caractère. Par exemple, en langage C et en Java, il s'agit de "char".
+Dans certains langages, il existe un type spécial "character" pour un seul caractère. Par exemple, en langage C et en Java, il s'agit de "char".
 
 En JavaScript, ce type n'existe pas. Il n'y a qu'un seul type: `string`. Une chaîne de caractères peut être composée de zéro caractère (être vide), d'un caractère ou de plusieurs d'entre eux.
 ```
@@ -170,7 +171,7 @@ alert( isGreater ); // true (le résultat de la comparaison est "oui")
 
 Nous couvrirons plus profondément les booléens plus tard dans le chapitre <info:logical-operators>.
 
-## La valeur "null" 
+## La valeur "null"
 
 La valeur spéciale `null` n'appartient à aucun type de ceux décrits ci-dessus.
 
@@ -186,7 +187,7 @@ C’est juste une valeur spéciale qui a le sens de "rien", "vide" ou "valeur in
 
 Le code ci-dessus indique que l'`age` est inconnu.
 
-## La valeur "undefined" 
+## La valeur "undefined"
 
 La valeur spéciale `undefined` se distingue des autres. C'est un type à part entière, comme `null`.
 
@@ -217,7 +218,7 @@ alert(age); // "undefined"
 
 Le type `object` est spécial.
 
-Tous les autres types sont appelés "primitifs", car leurs valeurs ne peuvent contenir qu’une seule chose (que ce soit une chaîne de caractères, un nombre ou autre). À contrario, les objets servent à stocker des collections de données et des entités plus complexes. 
+Tous les autres types sont appelés "primitifs", car leurs valeurs ne peuvent contenir qu’une seule chose (que ce soit une chaîne de caractères, un nombre ou autre). À contrario, les objets servent à stocker des collections de données et des entités plus complexes.
 
 Étant aussi important, les objets méritent un traitement spécial. Nous les traiterons plus tard dans le chapitre <info:object>, après en savoir plus sur les primitifs.
 

--- a/1-js/06-advanced-functions/03-closure/article.md
+++ b/1-js/06-advanced-functions/03-closure/article.md
@@ -197,7 +197,7 @@ Tout semble simple pour l'instant, non ?
 - Travailler avec des variables, c'est travailler avec les propriétés de cet objet.
 
 ```smart header="L'environnement lexical est un objet de spécification"
-"L'environnement lexical" est un objet de spécification : il n'existe que "théoriquement" dans la [spécification du language](https://tc39.es/ecma262/#sec-lexical-environments) pour décrire comment les choses fonctionnent. nous ne pouvons pas obtenir cet objet dans notre code et le manipuler directement.
+"L'environnement lexical" est un objet de spécification : il n'existe que "théoriquement" dans la [spécification du langage](https://tc39.es/ecma262/#sec-lexical-environments) pour décrire comment les choses fonctionnent. nous ne pouvons pas obtenir cet objet dans notre code et le manipuler directement.
 
 Les moteurs JavaScript peuvent également l'optimiser, supprimer les variables inutilisées pour économiser de la mémoire et effectuer d'autres opérations internes, tant que le comportement visible reste conforme à la description.
 

--- a/1-js/11-async/02-promise-basics/article.md
+++ b/1-js/11-async/02-promise-basics/article.md
@@ -10,10 +10,10 @@ C'est une analogie réelle à un problème courant de programmation :
 
 1. Un "producteur de code" qui réalise quelque chose mais nécessite du temps. Par exemple, un code qui charge des données à travers un réseau. C'est le "chanteur".
 2. Un "consommateur de code" qui attend un résultat du "producteur de code" quand il est prêt. Beaucoup de fonctions peuvent avoir besoin de ce résultat. Ces fonctions sont les "fans".
-3. Une *promesse* (promise) est un objet spécial en Javascript qui lie le "producteur de code" et le "consommateur de code" ensemble. En comparant à notre analogie c'est la "liste d'abonnement". Le "producteur de code" prend le temps nécessaire pour produire le résultat promis, et la "promesse" donne le résultat disponible pour le code abonné quand c'est prêt.
+3. Une *promesse* (promise) est un objet spécial en JavaScript qui lie le "producteur de code" et le "consommateur de code" ensemble. En comparant à notre analogie c'est la "liste d'abonnement". Le "producteur de code" prend le temps nécessaire pour produire le résultat promis, et la "promesse" donne le résultat disponible pour le code abonné quand c'est prêt.
 
 
-L'analogie n'est pas la plus correcte, car les promesses en Javascript sont un peu plus complexes qu'une simple liste d'abonnement : elles ont d'autres possibilités mais aussi certaines limitations. Toutefois c'est suffisant pour débuter.
+L'analogie n'est pas la plus correcte, car les promesses en JavaScript sont un peu plus complexes qu'une simple liste d'abonnement : elles ont d'autres possibilités mais aussi certaines limitations. Toutefois c'est suffisant pour débuter.
 
 
 La syntaxe du constructeur pour une promesse est :
@@ -26,7 +26,7 @@ let promise = new Promise(function(resolve, reject) {
 
 La fonction passée à `new Promise` est appelée l'*exécuteur*. Quand `new Promise` est créée, elle est lancée automatiquement. Elle contient le producteur de code, qui doit produire un résulat final. Dans l'analogie ci-dessus : l'exécuteur est le "chanteur".
 
-Ses arguments `resolve` (tenir) et `reject` (rompre) sont les fonctions de retour directement fournies par Javascript. Notre code est inclus seulement dans l'exécuteur.
+Ses arguments `resolve` (tenir) et `reject` (rompre) sont les fonctions de retour directement fournies par JavaScript. Notre code est inclus seulement dans l'exécuteur.
 
 Quand l'exécuteur obtient un résultat, qu'il soit rapide ou pas, cela n'a pas d'importance, il appellera une des deux fonctions de retour :
 
@@ -59,7 +59,7 @@ let promise = new Promise(function(resolve, reject) {
 On peut voir deux choses en lançant le code ci-dessus :
 
 1. L'exécuteur est appelé automatiquement et immédiatement (avec `new Promise`).
-2. L'exécuteur reçoit deux arguments : `resolve` et `reject` - ces deux fonctions sont pré-définies par le moteur Javascript, ainsi nous n'avons pas besoin de les créer. Nous devons seulement appeler l'une ou l'autre quand le résultat est prêt.
+2. L'exécuteur reçoit deux arguments : `resolve` et `reject` - ces deux fonctions sont pré-définies par le moteur JavaScript, ainsi nous n'avons pas besoin de les créer. Nous devons seulement appeler l'une ou l'autre quand le résultat est prêt.
 
     Après une seconde de "traitement" l'exécuteur appelle `resolve("done")` pour produire le résultat. Cela change l'état de l'objet `promise` :
 

--- a/1-js/11-async/07-microtask-queue/article.md
+++ b/1-js/11-async/07-microtask-queue/article.md
@@ -109,4 +109,4 @@ Ainsi, les gestionnaires `.then/catch/finally` sont toujours appelés une fois l
 
 Si nous devons garantir qu'un morceau de code est exécuté après `.then/catch/finally`, nous pouvons l'ajouter à un appel `.then` enchaîné.
 
-Dans la plupart des moteurs Javascript, y compris les navigateurs et Node.js, le concept de micro-tâches est étroitement lié à la "boucle d'événement" et aux "macrotaches". Comme elles n’ont pas de relation directe avec les promesses, elles sont décrites dans une autre partie du didacticiel, au chapitre <info:event-loop>.
+Dans la plupart des moteurs JavaScript, y compris les navigateurs et Node.js, le concept de micro-tâches est étroitement lié à la "boucle d'événement" et aux "macrotaches". Comme elles n’ont pas de relation directe avec les promesses, elles sont décrites dans une autre partie du didacticiel, au chapitre <info:event-loop>.

--- a/2-ui/1-document/04-searching-elements-dom/article.md
+++ b/2-ui/1-document/04-searching-elements-dom/article.md
@@ -2,7 +2,7 @@
 
 Les outils de navigation du DOM sont très pratiques quand les éléments sont proches les uns des autres. Mais s'ils ne le sont pas ? Comment atteindre un élément arbitraire de la page ?
 
-Il existe d'autres méthodes de recherche pour cela. 
+Il existe d'autres méthodes de recherche pour cela.
 
 ## document.getElementById ou juste id
 
@@ -41,7 +41,7 @@ Il y a aussi une variable globale nommée selon l'`id` qui référence l'éléme
 </script>
 ```
 
-...A moins qu'on déclare une variable Javascript avec le même nom, auquel cas celle-ci obtient la priorité :
+...A moins qu'on déclare une variable JavaScript avec le même nom, auquel cas celle-ci obtient la priorité :
 
 ```html run untrusted height=0
 <div id="elem"></div>
@@ -144,9 +144,9 @@ Les *ancêtres* d'un élément sont : le parent, le parent du parent, son propre
 
 La méthode `elem.closest(css)` cherche l'ancêtre le plus proche qui correspond au sélecteur CSS. L'élément `elem` est lui-même inclus dans la recherche.
 
-En d'autres mots, la méthode `closest` part de l'élément et remonte en regardant chacun des parents. S'il correspond au sélecteur, la recherche s'arrête et l'ancêtre est renvoyé. 
+En d'autres mots, la méthode `closest` part de l'élément et remonte en regardant chacun des parents. S'il correspond au sélecteur, la recherche s'arrête et l'ancêtre est renvoyé.
 
-Par exemple : 
+Par exemple :
 
 ```html run
 <h1>Contenu</h1>
@@ -174,7 +174,7 @@ Il y a aussi d'autres méthodes pour rechercher des balises par tag, classe, etc
 
 Aujourd'hui, elles sont principalement de l'histoire ancienne, car `querySelector` est plus puissante et plus courte à écrire.
 
-Donc ici, on va surtout en parler dans le souci d'être complet, comme elles peuvent encore se retrouver dans des vieux scripts. 
+Donc ici, on va surtout en parler dans le souci d'être complet, comme elles peuvent encore se retrouver dans des vieux scripts.
 
 - `elem.getElementsByTagName(tag)` cherche les éléments avec le tag donné et renvoie l'ensemble de ces éléments. Le paramètre `tag` peut aussi être une étoile `"*"` pour signifier n'importe quel tag.
 - `elem.getElementsByClassName(className)` renvoie les éléments qui ont la classe CSS donnée.
@@ -182,7 +182,7 @@ Donc ici, on va surtout en parler dans le souci d'être complet, comme elles peu
 
 Par exemple:
 ```js
-// récupérer tous les divs du document. 
+// récupérer tous les divs du document.
 let divs = document.getElementsByTagName('div');
 ```
 
@@ -225,14 +225,14 @@ La lettre `"s"` letter n'apparait pas dans `getElementById`, car cette méthode 
 ```
 
 ````warn header="Elle renvoie un ensemble, pas un élément !"
-Une autre erreur répandue parmi les débutants est d'écrire : 
+Une autre erreur répandue parmi les débutants est d'écrire :
 
 ```js
-// ne fonctionne pas : 
+// ne fonctionne pas :
 document.getElementsByTagName('input').value = 5;
 ```
 
-Cela ne va pas marcher, parce qu'on essaie d'affecter une valeur à un ensemble d'objets plutôt qu'à un élément de cet ensemble. 
+Cela ne va pas marcher, parce qu'on essaie d'affecter une valeur à un ensemble d'objets plutôt qu'à un élément de cet ensemble.
 On devrait plutôt itérer sur l'ensemble ou récupérer un élément par son index, et lui affecter la valeur, comme ceci :
 
 ```js
@@ -263,7 +263,7 @@ Recherche des éléments `.article` :
 
 Toutes les méthodes `"getElementsBy*"` renvoient l'ensemble *courant*. De tels ensembles montrent toujours l'état courant du document and se mettent à jour automatiquement quand celui-ci change.
 
-Dans l'exemple ci-dessous, il y a deux scripts : 
+Dans l'exemple ci-dessous, il y a deux scripts :
 
 1. Le premier crée une référence à l'ensemble des `<div>`. Maintenant, sa longueur est `1`.
 2. Le second se lance après que le navigateur aie rencontré un autre `<div>`, donc sa longueur est `2`.
@@ -311,7 +311,7 @@ Maintenant, on voit facilement la différence. L'ensemble statique ne s'est pas 
 
 ## Résumé
 
-Il y a 6 principales méthodes pour rechercher des balises dans le DOM : 
+Il y a 6 principales méthodes pour rechercher des balises dans le DOM :
 
 <table>
 <thead>
@@ -362,7 +362,7 @@ Il y a 6 principales méthodes pour rechercher des balises dans le DOM :
 </tbody>
 </table>
 
-De loin, les plus utilisées sont `querySelector` et `querySelectorAll`, mais `getElement(s)By*` peut être de temps en temps utile ou rencontrée dans de vieux scripts. 
+De loin, les plus utilisées sont `querySelector` et `querySelectorAll`, mais `getElement(s)By*` peut être de temps en temps utile ou rencontrée dans de vieux scripts.
 
 A part ça :
 

--- a/2-ui/2-events/04-default-browser-action/article.md
+++ b/2-ui/2-events/04-default-browser-action/article.md
@@ -8,7 +8,7 @@ Par exemple:
 - Un clic sur un bouton d'envoi de formulaire -- initie son envoie vers le serveur.
 - Appuyer sur un bouton de la souris au-dessus d'un texte et la déplacer -- sélectionne le texte.
 
-Si nous gérons un évènement avec Javascript, nous pouvons ne pas avoir envie de déclencher l'action de navigateur associée, et déclencher un autre comportement à la place.
+Si nous gérons un évènement avec JavaScript, nous pouvons ne pas avoir envie de déclencher l'action de navigateur associée, et déclencher un autre comportement à la place.
 
 ## Empêcher les actions du navigateur
 
@@ -25,7 +25,7 @@ ou
 <a href="/" onclick="event.preventDefault()">ici</a>
 ```
 
-Dans le prochain exemple nous allons utiliser cette technique pour créer un menu avec Javascript.
+Dans le prochain exemple nous allons utiliser cette technique pour créer un menu avec JavaScript.
 
 ```warn header="Renvoyer `false` depuis un gestionnaire d'évènement est une exception"
 La valeur renvoyée par un gestionnaire d'évènement est généralement ignorée.
@@ -56,7 +56,7 @@ Les objets du menu sont implémentés comme des liens HTML `<a>`, pas des bouton
 - Beaucoup de gens aiment utiliser "clic droit" -- "ouvrir dans une nouvelle fenêtre". Si nous utilisons `<button>` ou `<span>`, cela ne fonctionne pas.
 - Les moteurs de recherche suivent les liens `<a href="...">` lors de l'indexation.
 
-Donc nous utilisons `<a>`. Mais normalement nous avons l'intention de gérer les clics avec Javascript. Donc nous devrions empêcher les actions par défaut du navigateur.
+Donc nous utilisons `<a>`. Mais normalement nous avons l'intention de gérer les clics avec JavaScript. Donc nous devrions empêcher les actions par défaut du navigateur.
 
 Comme ici:
 
@@ -225,7 +225,7 @@ Il y a plusieurs actions de navigateur par défaut:
 - `contextmenu` -- l'évènement se déclenche lors d'un clic droit, l'action est d'afficher le menu contextuel du navigateur.
 - ...il y en a plus...
 
-Toutes les actions par défaut peuvent être empêchées si nous voulons gérer l'évènement exclusivement avec Javascript.
+Toutes les actions par défaut peuvent être empêchées si nous voulons gérer l'évènement exclusivement avec JavaScript.
 
 Pour empêcher une action par défaut -- utilisez soit `event.preventDefault()`, soit `return false`. La seconde méthode ne fonctionne que pour les gestionnaires assignés avec `on<event>`.
 
@@ -234,11 +234,11 @@ L'option `passive: true` de `addEventListener` dis au navigateur que l'action ne
 Si l'action par défaut a été empêchée, la valeur de `event.defaultPrevented` devient `true`, sinon `false`.
 
 ```warn header="Restez sémantique, n'abusez pas"
-Techniquement, en empêchant les actions par défaut et en ajoutant du Javascript nous pouvons personnaliser le comportement de n'importe quel élément. Par exemple, nous pouvons faire fonctionner un lien `<a>` comme un bouton, et un bouton `<button>` se comporter comme un lien (rediriger vers une autre URL ou autre).
+Techniquement, en empêchant les actions par défaut et en ajoutant du JavaScript nous pouvons personnaliser le comportement de n'importe quel élément. Par exemple, nous pouvons faire fonctionner un lien `<a>` comme un bouton, et un bouton `<button>` se comporter comme un lien (rediriger vers une autre URL ou autre).
 
 Mais nous devrions généralement garder la signification sémantique des éléments HTML. Par exemple `<a>` devrait entrainer une navigation, pas un bouton.
 
 Ce n'est pas "juste une bonne chose", cela rend votre HTML meilleur en terme d'accessibilité.
 
-Aussi, si nous prenons l'exemple avec `<a>`, veuillez noter: un navigateur nous permet d'ouvrir de tels liens dans une nouvelle fenêtre (en faisant un clic droit dessus par exemple). Et les gens aiment ça. Mais si nous faisons un bouton qui se comporte comme un lien en utilisant Javascript et qui ressemble à un lien en utilisant CSS, les fonctionnalités de navigateur spécifiques à `<a>` ne fonctionneront toujours pas.
+Aussi, si nous prenons l'exemple avec `<a>`, veuillez noter: un navigateur nous permet d'ouvrir de tels liens dans une nouvelle fenêtre (en faisant un clic droit dessus par exemple). Et les gens aiment ça. Mais si nous faisons un bouton qui se comporte comme un lien en utilisant JavaScript et qui ressemble à un lien en utilisant CSS, les fonctionnalités de navigateur spécifiques à `<a>` ne fonctionneront toujours pas.
 ```

--- a/2-ui/3-event-details/7-keyboard-events/2-check-sync-keydown/task.md
+++ b/2-ui/3-event-details/7-keyboard-events/2-check-sync-keydown/task.md
@@ -6,7 +6,7 @@ importance: 5
 
 Créer une fonction `runOnKeys(func, code1, code2, ... code_n)` exécutant la fonction `func` lorsqu’on appuie simultanément sur les touches avec les codes suivant `code1`, `code2`, ..., `code_n`.
 
-Par exemple, le code en dessous montre  `alert` lorsque `"Q"` et `"W"` sont appuyées ensemble (dans n'importe quelle langue, avec ou sans l'activation de La touche Majuscule,  CapsLock)
+Par exemple, le code ci-dessous montre `alert` lorsque `"Q"` et `"W"` sont appuyées ensemble (dans n'importe quelle langue, avec ou sans l'activation de La touche Majuscule,  CapsLock)
 
 ```js no-beautify
 runOnKeys(
@@ -17,4 +17,3 @@ runOnKeys(
 ```
 
 [demo src="solution"]
-

--- a/2-ui/3-event-details/7-keyboard-events/article.md
+++ b/2-ui/3-event-details/7-keyboard-events/article.md
@@ -1,13 +1,10 @@
-# Le Clavier: les évènements keydown et keyup 
+# Le Clavier: les évènements keydown et keyup
 
 Avant que nous en arrivions au clavier, veuillez noter que sur des appareils modernes il y a d'autres manières de “récupérer quelque chose". Par exemple, les gens utilisent la reconnaissance vocale (en particulier sur les appareils mobiles) oubien le copier/coller avec la souris.
 
-
 Donc si nous voulons contrôler une entrée dans un champ `<input>`, alors les évènements du clavier ne sont pas assez suffisants. Il y a un autre évènement nommé `input` pour gérer les changements d'un champ `<input>`, par n'importe quelle moyen. Et il peut être un meilleur choix pour une telle tâche. Nous allons traiter cela plus tard dans le chapitre <info:events-change-input>.
 
-
 Les évènements du clavier doivent être utilisés  lorsqu'on veut gérer les actions sur le clavier (Le clavier virtuel compte aussi). Par exemple, pour réagir sur les touches de directions `key:Up` et `key:Down` oubien les touches de raccourcis (y compris les combinaisons de touches).
-
 
 ## Teststand [#keyboard-test-stand]
 
@@ -23,7 +20,6 @@ Essayez les différentes combinaisons de touches dans la zone de texte.
 [codetabs src="keyboard-dump" height=480]
 ```
 
-
 ## Keydown et keyup
 
 Les évènements  `keydown` surviennent lorsqu'une touche est appuyée, et ensuite intervient `keyup` -- lorsqu'elle est relâchée.
@@ -32,9 +28,7 @@ Les évènements  `keydown` surviennent lorsqu'une touche est appuyée, et ensui
 
 La propriété `key` de l’objet évènement permet d'obtenir un caractère, tandis que la propriété `code` de l'objet évènement objet permet d'obtenir  le "code de la touche physique".
 
-
 Par exemple, la même touche `key:Z`  peut être appuyée avec ou sans `key:Shift`. Cela nous donne deux caractères différents : minuscule `z` et majuscule `Z`.
-
 
 La propriété `event.key` est exactement le caractère, et il sera diffèrent. Cependant `event.code` est la même:
 
@@ -42,7 +36,6 @@ La propriété `event.key` est exactement le caractère, et il sera diffèrent. 
 |--------------|-------------|--------------|
 | `key:Z`      |`z` (minuscule)         |`KeyZ`        |
 | `key:Shift+Z`|`Z` (majuscule)          |`KeyZ`        |
-
 
 Si un utilisateur travaille avec des langues différentes, alors le fait de changer vers une autre langue aura pour effet de créer un caractère totalement diffèrent de `"Z"`.  Cela va devenir la valeur de `event.key`, tandis que `event.code` est toujours la même que: `"KeyZ"`.
 
@@ -56,7 +49,6 @@ Par exemple:
 
 Il existe plusieurs formats de claviers usuels, différents de par la présentation, et la spécification donne des codes pour les touches pour chacun d'entre eux.
 
-
 voir [la section alphanumérique de la specification](https://www.w3.org/TR/uievents-code/#key-alphanumeric-section) pour plus de codes, ou essayez juste le [teststand](#keyboard-test-stand) au-dessus.
 
 ```
@@ -66,7 +58,6 @@ Semble être évident, mais beaucoup de gens font toujours des fautes.
 
 S'il vous plait éviter les fautes de frappes: c'est `KeyZ`, pas `keyZ`. Le control tel que `event.code=="keyZ"` ne vas pas fonctionner: la première lettre de `"Key"` doit être une majuscule.
 ```
-
 
 Et si une touche ne donne aucun caractère ? Par exemple, `key:Shift` ou `key:F1` ou autres.  Pour ces touches, `event.key` est approximativement la même chose que `event.code` :
 
@@ -87,7 +78,6 @@ Il existe un dilemme ici: Dans cet écouteur d’évènement, devons-nous contr�
 
 D'une part, la valeur de `event.key` est un caractère, elle change en fonction de la langue. Si le visiteur a plusieurs langues dans le système d'exploitation et bascule entre elles, la même clé donne des caractères différents. Il est donc logique de vérifier `event.code`, c'est toujours pareil.
 
-
 Ainsi:
 
 ```js run
@@ -98,18 +88,15 @@ document.addEventListener('keydown', function(event) {
 });
 ```
 
-
 D'autre part, il existe un problème avec `event.code`. Pour des dispositions de clavier différentes, la même touche peut avoir des caractères différents.
 
 Par exemple, voici la disposition du clavier Américain ("QWERTY") et Allemand ("QWERTZ") dessous (de Wikipedia) :
-
 
 ![](us-layout.svg)
 
 ![](german-layout.svg)
 
 Pour la même touche, le clavier Américain a un "Z", tandis que celui Allemand a un "Y" (les lettres sont échanges).
-
 
 Donc, `event.code` sera égal à `KeyZ` pour les gens utilisant le clavier Allemand lorsqu'ils appuient sur `key:Y`.
 
@@ -127,13 +114,11 @@ Voulons-nous gérer des clés dépendantes de la disposition ? Alors `event.key`
 
 Ou voulons-nous un raccourci clavier même après un changement de langue ? Alors, `event.code` peut être une meilleure option.
 
-
 ## Auto-repeat
 
 Si une touche est appuyée assez longtemps, elle commence la répétition avec la propriété "auto-repeat": l'évènement `keydown` se déclenche de manière répétitive, et ensuite lorsqu'elle est relâchée nous obtenons finalement l'évènement `keyup`. Donc c'est normal d'avoir plusieurs `keydown`  et un unique évènement `keyup`.
 
 Pour les évènements déclenchés par auto-repeat, l'évènement objet a une propriété `event.repeat` dont la valeur est assignée à `true`.
-
 
 ## Actions par défaut
 
@@ -189,7 +174,6 @@ L'approche alternative serait de suivre l'événement `oninput` -- il se déclen
 Dans le passé, il y'avait un évènement `keypress`, et aussi les propriétés `keyCode`, `charCode`, `which` de l'objet évènement.
 
 Il y avait tellement d'incompatibilités au niveau des navigateurs en travaillant avec eux que les développeurs de la spécification n'avaient autre moyen que de les déprécier tous et d’en créer de  nouveaux et plus modernes (tels que ceux décrits en haut dans ce chapitre). L'ancien code marche encore, étant donné que les navigateurs continuent de les supporter, mais nous n'avons nullement besoin de les utiliser maintenant.
-
 
 ## Claviers mobiles
 

--- a/3-frames-and-windows/01-popup-windows/article.md
+++ b/3-frames-and-windows/01-popup-windows/article.md
@@ -2,33 +2,32 @@
 
 Une fenêtre pop-up est l'une des plus anciennes méthodes pour montrer un document supplémentaire à l'utilisateur.
 
-Le code suivant:
+Le code suivant :
+
 ```js
 window.open('https://javascript.info/')
 ```
 
 ... Et cela Ouvrira simplement une nouvelle fenêtre avec l'url renseignée. La plupart des navigateurs modernes sont configurés pour ouvrir un nouvel onglet plutôt qu'une nouvelle feneêtre.
 
-Les pop-up existent depuis longtemps. L'idée initiale était de montrer du contenu supplémentaire sans fermer la fenêtre principale. Désormais, il y a d'autres manières de faire ça : on peut charger du contenu dynamiquement avec [fetch](info:fetch) et l'afficher dans une `<div>` générée dynamiquement. Les pop-up ne sont donc plus des choses utilisées de nos jours. 
+Les pop-up existent depuis longtemps. L'idée initiale était de montrer du contenu supplémentaire sans fermer la fenêtre principale. Désormais, il y a d'autres manières de faire ça : on peut charger du contenu dynamiquement avec [fetch](info:fetch) et l'afficher dans une `<div>` générée dynamiquement. Les pop-up ne sont donc plus des choses utilisées de nos jours.
 
 Les pop-up sont également délicate sur les appareils mobiles puis que ces derniers ne peuvent pas afficher plusieurs fenêtres simultanément.
 
-
 Pourtant, il y a quelques tâches où les pop-up sont toujours utilisées, par exemple pour les authentifications OAuth (se connecter avec Google/Facebook..) pour les raisons suivantes :
 
-1. Une pop-up est une fenêtre séparée avec son environnement JavaScript indépendant. Donc ouvrir une pop-up d'une tierce partie venant d'un site peu fiable est sécurisé. 
+1. Une pop-up est une fenêtre séparée avec son environnement JavaScript indépendant. Donc ouvrir une pop-up d'une tierce partie venant d'un site peu fiable est sécurisé.
 2. Il est très facile d'ouvrir une pop-up.
 3. Une pop-up peut naviguer, changer d'url et envoyer des messages à la fenêtre qui l'a ouverte.
 
-
 ## Bloquage de pop-up
-
 
 Dans le passé, des sites malveillant usaient des pop-up à outrance. Une mauvaise page pouvait ouvrir beaucoup de fenêtre pop-up avec des pubs. Désormais, la plupart des navigateurs essaient de bloquer les pop-up et de protéger les utilisateurs.
 
 **Beaucoup de navigateurs bloquent les pop-up si elles sont appelés à l'extérieur de gestionnaire d'évènements déclenchés par l'utilisateurs comme `onclick`.**
 
-Par exemple:
+Par exemple :
+
 ```js
 // popup bloquée
 window.open('https://javascript.info');
@@ -75,12 +74,11 @@ params
 
 : La chaîne de caractères de la configuration pour la nouvelle fenêtre. Elle peut contenir des paramètres séparés par une virgule. Il ne peut pas y avoir d'espace dans les paramètres, par exemple : `width:200,height=100`.
 
+Paramètres de `params` :
 
-Paramètres de `params`:
-
-- Position:
+- Position :
   - `left/top` (numeric) -- paramètre la distance de la bordure gauche/supérieure par rapport à la zone de travail. Il y a une limitation : une nouvelle fenêtre ne peux pas dépasser de l'écran ou être positionnée à l'extérieur de celui ci.
-  - `width/height` (numeric) -- paramètre la largeur et la hauteur de la nouvelle fenêtre. La valeur minimale requise est de 100, il est donc impossible de créer une fenêtre invisible. 
+  - `width/height` (numeric) -- paramètre la largeur et la hauteur de la nouvelle fenêtre. La valeur minimale requise est de 100, il est donc impossible de créer une fenêtre invisible.
 - Caractéristiques de la fenêtre:
   - `menubar` (yes/no) -- affiche ou cache la barre de menu du navigateur de la nouvelle fenêtre.
   - `toolbar` (yes/no) -- affiche ou cache la barre de navigation (bouton précédente, suivante, actualiser etc) de la nouvelle fenêtre.
@@ -89,12 +87,11 @@ Paramètres de `params`:
   - `resizable` (yes/no) -- autorise ou désactive le redimensionnement de la nouvelle fenêtre. Non recommandé.
   - `scrollbars` (yes/no) -- autorise ou désactive la barre de défilement de la nouvelle fenêtre. Non recommandé.
 
-
 Il existe également certains paramètres spécifiques aux navigateurs qui sont moins bien supportés et généralement pas utilisés. Consultez <a href="https://developer.mozilla.org/fr/docs/Web/API/Window/open"> window.open sur MDN</a> pour plus d'exemples.
 
-## Exemple: une fenêtre minimaliste  
+## Exemple: une fenêtre minimaliste
 
-Ouvrons une fenêtre avec le minimum de paramètres fonctionnels juste pour voir quels navigateurs nous autorise à les désactiver : 
+Ouvrons une fenêtre avec le minimum de paramètres fonctionnels juste pour voir quels navigateurs nous autorise à les désactiver :
 
 ```js run
 let params = `scrollbars=no,resizable=no,status=no,location=no,toolbar=no,menubar=no,
@@ -127,7 +124,7 @@ Règles des paramètres omis:
 
 La fonction `open` retourne une référence à la nouvelle fenêtre. Celle ci peut être utilisée pour manipuler ses propriétés, changer sa localisation et bien plus.
 
-Dans cet exemple, nous générons du contenu en pop-up avec Javascript: 
+Dans cet exemple, nous générons du contenu en pop-up avec JavaScript :
 
 ```js
 let newWin = window.open("about:blank", "hello", "width=200,height=200");
@@ -152,7 +149,6 @@ newWindow.onload = function() {
 ```
 
 Il faut prendre en compte qu'immédiatement après avoir appelé `window.open`, la nouvelle fenêtre ne s'est pas encore chargée. On peut le constater avec `alert` à la ligne `(*)`. Nous devons donc attendre la fonction `onload` pour modifier cette fenêtre. Nous pourrions également utiliser l'évènement `DOMContentLoaded` pour `newWin.document`.
-
 
 ```warn header="Same origin policy"
 Les fenêtres peuvent avoir accès au contenu de chacunes d'entres elles si elles ont la même origine (le même protocol://domain:port).
@@ -196,7 +192,6 @@ newWindow.onload = function() {
   alert(newWindow.closed); // true
 };
 ```
-
 
 ## Se déplacer et redimensionner
 
@@ -244,18 +239,15 @@ Il existe un évènement `window.onscroll`.
 
 ## Mettre ou enlever le focus sur une fenêtre
 
-
 Théoriquement, il existe des méthodes `window.focus()` et `window.blur()` pour faire/défaire le focus sur une fenêtre.  Il existe également des événements `focus/blur` qui permettent de saisir le moment où le visiteur focus une fenêtre et passe ailleurs.
 
 Bien que, dans la pratique, ils soient sévèrement limités, car dans le passé, des pages malveillantes en abusaient.
 
 Par exemple, regardez ce code :
 
-
 ```js run
 window.onblur = () => window.focus();
 ```
-
 
 Lorsqu'un utilisateur tente de sortir de la fenêtre (`window.onblur`), le focus va revenir dessus. L'intention est de "verrouiller" l'utilisateur dans la `window`.
 
@@ -265,12 +257,12 @@ Par exemple, un navigateur mobile ignore généralement complètement `window.fo
 
 Pourtant, il existe des cas d'utilisation où de tels appels fonctionnent et peuvent être utiles.
 
-Par exemple:
+Par exemple :
 
 - Lorsque nous ouvrons une pop-up, l peut être judicieux d'y lancer un `newWindow.focus()`. Juste au cas où, pour certaines combinaisons de systèmes d'exploitation/navigateurs, cela garantit que l'utilisateur se trouve maintenant dans la nouvelle fenêtre.
 - Si nous voulons savoir quand un visiteur utilise réellement notre application Web, nous pouvons suivre `window.onfocus/onblur`. Cela nous permet de suspendre/reprendre les activités sur la page, les animations, etc. Mais veuillez noter que l'événement `blur` signifie que le visiteur est sorti de la fenêtre, mais qu'il peut toujours l'observer. La fenêtre est en arrière-plan, mais peut toujours être visible.
 
-## Résumé  
+## Résumé
 
 Les fenêtres pop-up sont rarement utilisées, car il existe des alternatives : chargement et affichage des informations dans la page, ou dans l'iframe.
 

--- a/9-regular-expressions/08-regexp-character-sets-and-ranges/article.md
+++ b/9-regular-expressions/08-regexp-character-sets-and-ranges/article.md
@@ -90,7 +90,7 @@ Cet ensemble est bien sûr encore modifiable : on peut y ajouter ou retirer des 
 ```warn header="Les propriétés Unicode ne sont pas supportées par IE"
 Les propriétés Unicode `pattern:p{…}` ne sont pas implémentées dans IE. Si nous en avons vraiment besoin, nous pouvons utiliser la librairie [XRegExp](https://xregexp.com/).
 
-Ou simplement utiliser des intervalles de caractères dans la langue qui nous intéresse, p. ex.  `pattern:[а-я]` pour les lettres cyrilliques.
+Ou simplement utiliser des intervalles de caractères dans la langue qui nous intéresse, p. ex. `pattern:[а-я]` pour les lettres cyrilliques.
 ```
 
 ## Intervalles d'exclusion

--- a/9-regular-expressions/09-regexp-quantifiers/article.md
+++ b/9-regular-expressions/09-regexp-quantifiers/article.md
@@ -125,7 +125,7 @@ alert( "0 1 12.345 7890".match(/\d+\.\d+/g) ); // 12.345
 
 **Regexp "balise HTML d'ouverture ou de fermeture sans attributs": `pattern:/<\/?[a-z][a-z0-9]*>/i`**
 
-Nous avons ajouté un slash optionnel `pattern:/?` près du début du pattern. Nous avons dû l'échapper avec un backslash, sinon Javascript aurait pensé que c'était la fin du pattern.
+Nous avons ajouté un slash optionnel `pattern:/?` près du début du pattern. Nous avons dû l'échapper avec un backslash, sinon JavaScript aurait pensé que c'était la fin du pattern.
 
 ```js run
 alert( "<h1>Hi!</h1>".match(/<\/?[a-z][a-z0-9]*>/gi) ); // <h1>, </h1>

--- a/9-regular-expressions/11-regexp-groups/article.md
+++ b/9-regular-expressions/11-regexp-groups/article.md
@@ -185,7 +185,7 @@ Le résultat est un tableau de correspondance, mais sans les détails de chacune
 
 Pour les obtenir, nous devons rechercher avec la méthode `str.matchAll(regexp)`.
 
-Elle a été ajoutée au language JavaScript longtemps après `match`, comme étant sa "version nouvelle et améliorée".
+Elle a été ajoutée au langage JavaScript longtemps après `match`, comme étant sa "version nouvelle et améliorée".
 
 Tout comme `match`, elle cherche des correspondances, mais avec 3 différences :
 

--- a/9-regular-expressions/13-regexp-alternation/03-match-quoted-string/task.md
+++ b/9-regular-expressions/13-regexp-alternation/03-match-quoted-string/task.md
@@ -22,7 +22,7 @@ Exemple de chaine de caractère valides :
 .. *!*"\\ \""*/!* ..  (double backslash et guillemets échapées à l'intérieur)
 ```
 
-En Javascript nous devons doubler les slash pour les placer dans la chaine de caractère, comme ceci :
+En JavaScript nous devons doubler les slash pour les placer dans la chaine de caractère, comme ceci :
 
 ```js run
 let str = ' .. "test me" .. "Say \\"Hello\\"!" .. "\\\\ \\"" .. ';

--- a/9-regular-expressions/17-regexp-methods/article.md
+++ b/9-regular-expressions/17-regexp-methods/article.md
@@ -26,8 +26,8 @@ Elle dispose de 3 options :
     alert( result.input );  // I love JavaScript (chaîne sur laquelle a été effectuée la recherche)
     ```
 
-2. Si la `regexp` dispose d'un marqueur `pattern:g`, alors elle retourne un tableau de toutes les correspondances de texte, sans capturer les groupes ou les autres propriétés.    
-    
+2. Si la `regexp` dispose d'un marqueur `pattern:g`, alors elle retourne un tableau de toutes les correspondances de texte, sans capturer les groupes ou les autres propriétés.
+
     ```js run
     let str = "I love JavaScript";
 
@@ -60,7 +60,7 @@ Elle dispose de 3 options :
 
 [recent browser="new"]
 
-La méthode `str.matchAll(regexp)` est une variante "améliorée" de `str.match`. 
+La méthode `str.matchAll(regexp)` est une variante "améliorée" de `str.match`.
 
 Elle est principalement utilisée pour rechercher toutes les correspondances au sein de chaque groupe.
 
@@ -109,7 +109,7 @@ alert('12, 34, 56'.split(/,\s*/)) // array of ['12', '34', '56']
 
 ## str.search(regexp)
 
-La méthode `str.search(regexp)` renvoie l'indice du premier motif correspondant, ou `-1` si aucune correspondance n'est trouvée: 
+La méthode `str.search(regexp)` renvoie l'indice du premier motif correspondant, ou `-1` si aucune correspondance n'est trouvée:
 
 ```js run
 let str = "A drop of ink may make a million think";
@@ -119,11 +119,11 @@ alert( str.search( /ink/i ) ); // 10 (indice du premier motif correspondant)
 
 **Limitation importante: `search` renvoie uniquement la première correspondance.**
 
-Si nous avons besoin de l'indice ou de plus de correspondances, nous devrions utiliser d'autres méthodes, comme les trouver tous avec `str.matchAll(regexp)`. 
+Si nous avons besoin de l'indice ou de plus de correspondances, nous devrions utiliser d'autres méthodes, comme les trouver tous avec `str.matchAll(regexp)`.
 
 ## str.replace(str|regexp, str|func)
 
-Il s'agit d'une méthode générique pour chercher et remplacer une chaîne de caractères, l'une des plus utiles. Le couteau suisse pour chercher et remplacer. 
+Il s'agit d'une méthode générique pour chercher et remplacer une chaîne de caractères, l'une des plus utiles. Le couteau suisse pour chercher et remplacer.
 
 Nous pouvons l'utiliser sans regexps, pour chercher et remplacer une sous-chaîne de caractères:
 
@@ -136,12 +136,12 @@ Toutefois, il y a un piège.
 
 **Quand le premier argument de `replace` est une chaîne de caractères, elle ne remplace que la première occurence.**
 
-Vous pouvez constater dans l'exemple ci-dessous que seul le premier `"-"` est remplacé par `":"`. 
+Vous pouvez constater dans l'exemple ci-dessous que seul le premier `"-"` est remplacé par `":"`.
 
-Pour trouver tous les traits d'unions, nous devons utiliser non pas le caractère `"-"`, mais une expression rationnelle `pattern:/-/g`, avec obligatoirement le marqueur `pattern:g`;   
+Pour trouver tous les traits d'unions, nous devons utiliser non pas le caractère `"-"`, mais une expression rationnelle `pattern:/-/g`, avec obligatoirement le marqueur `pattern:g`;
 
 ```js run
-// remplace tous les tirets par deux-points 
+// remplace tous les tirets par deux-points
 alert( '12-34-56'.replace( *!*/-/g*/!*, ":" ) )  // 12:34:56
 ```
 
@@ -181,7 +181,7 @@ La fonction est appelée avec des arguments `func(match, p1, p2, ..., pn, offset
 
 Si la regexp ne comporte pas de parenthèses, alors la fonction ne contient que 3 arguments: `func(str, offset, input)`.
 
-Par exemple, pour convertir les chaînes de caractères correspondantes en majuscule: 
+Par exemple, pour convertir les chaînes de caractères correspondantes en majuscule:
 
 ```js run
 let str = "html and css";
@@ -217,7 +217,7 @@ let result = str.replace(/(\w+) (\w+)/, (...match) => `${match[2]}, ${match[1]}`
 alert(result); // Smith, John
 ```
 
-Ou, si nous utilisons des groupes nommés, alors l'objet `groups` est toujours placé en dernier, et nous pouvons l'obtenir de cette façon: 
+Ou, si nous utilisons des groupes nommés, alors l'objet `groups` est toujours placé en dernier, et nous pouvons l'obtenir de cette façon:
 
 ```js run
 let str = "John Smith";
@@ -256,7 +256,7 @@ La méthode `regexp.exec(str)` renvoie une correspondance for `regexp` dans la c
 
 Elle se comporte différement selon que la regexp dispose d'un marqueur `pattern:g` ou non.
 
-Si `pattern:g` n'est pas présent, alors `regexp.exec(str)` renvoie la première correspondance tel que le ferait `str.match(regexp)`. Ce comportement n'apporte rien de nouveau.  
+Si `pattern:g` n'est pas présent, alors `regexp.exec(str)` renvoie la première correspondance tel que le ferait `str.match(regexp)`. Ce comportement n'apporte rien de nouveau.
 
 Mais si `pattern:g` est utilisé, alors:
 - Un appel à `regexp.exec(str)` renvoie la première correspondance et sauvegarde l'indice situé juste après, accessible via la propriété `regexp.lastIndex`.
@@ -266,7 +266,7 @@ Mais si `pattern:g` est utilisé, alors:
 
 Donc, un appel répété à cette fonction renvoie toutes les correspondances l'une après l'autre, utilisant la propriété `regexp.lastIndex` pour se souvenir de l'indice courant à partir duquel la recherche est effectuée.
 
-Avant que la méthode `str.matchAll` ait été ajoutée à Javascript, des appels à `regexp.exec` étaient utilisés dans une boucle afin d'obtenir toutes les correspondances:  
+Avant que la méthode `str.matchAll` ait été ajoutée à JavaScript, des appels à `regexp.exec` étaient utilisés dans une boucle afin d'obtenir toutes les correspondances:
 
 ```js run
 let str = 'More about JavaScript at https://javascript.info';
@@ -281,7 +281,7 @@ while (result = regexp.exec(str)) {
 }
 ```
 
-Cela fonctionne également très bien, bien que sur les navigateurs les plus récents `str.matchAll` est généralement plus pratique. 
+Cela fonctionne également très bien, bien que sur les navigateurs les plus récents `str.matchAll` est généralement plus pratique.
 
 **Nous pouvons utiliser `regexp.exec` pour rechercher à partir d'un indice donné en réglant manuellement la valeur de `lastIndex`.**
 
@@ -291,12 +291,12 @@ Par exemple:
 let str = 'Hello, world!';
 
 let regexp = /\w+/g; // sans le marqueur "g", la propriété lastIndex est ignorée
-regexp.lastIndex = 5; // commence la recherche à partir de la 5ème position (à partir de la virgule)  
+regexp.lastIndex = 5; // commence la recherche à partir de la 5ème position (à partir de la virgule)
 
 alert( regexp.exec(str) ); // world
 ```
 
-Si la regexp utilise le marqueur `pattern:y`, alors la recherche s'effectuera à l'indice précis de `regexp.lastIndex`, pas plus loin. 
+Si la regexp utilise le marqueur `pattern:y`, alors la recherche s'effectuera à l'indice précis de `regexp.lastIndex`, pas plus loin.
 
 Remplaçons le marqueur `pattern:g` par `pattern:y` dans l'exemple précédent. Aucune correspondance n'est trouvée, car il n'y a aucun mot à l'indice `5`:
 
@@ -309,7 +309,7 @@ regexp.lastIndex = 5; // cherche exactement à l'indice 5
 alert( regexp.exec(str) ); // null
 ```
 
-C'est pratique dans une situation où nous cherchons uniquement à lire quelque chose au sein d'un texte avec une regexp à un indice spécifique, en occultant le reste. 
+C'est pratique dans une situation où nous cherchons uniquement à lire quelque chose au sein d'un texte avec une regexp à un indice spécifique, en occultant le reste.
 
 ## regexp.test(str)
 
@@ -334,7 +334,7 @@ alert( *!*/love/i*/!*.test(str) ); // false
 alert( str.search(*!*/love/i*/!*) != -1 ); // false
 ```
 
-Si la regexp à le marqueur `pattern:g`, alors `regexp.test` verifiera la propriété `regexp.lastIndex` et mettra à jours cette propriété, tout comme `regexp.exec`.    
+Si la regexp à le marqueur `pattern:g`, alors `regexp.test` verifiera la propriété `regexp.lastIndex` et mettra à jours cette propriété, tout comme `regexp.exec`.
 
 On peut donc l'utiliser pour effectuer une recherche à partir d'un indice donnée:
 
@@ -351,7 +351,7 @@ alert( regexp.test(str) ); // false (pas de correspondance)
 ````warn header="Une même expression rationnelle testée de manière répétée sur différentes sources peut échouer"
 Appliquer la même expression rationnelle globale sur différentes entrées peut conduire à de mauvais résultats, car l'appel à `regexp.test` modifie la propriété `regexp.lastIndex`, par conséquent la recherche sur une autre chaîne de caractères risque d'être lancer à partir d'un autre indice que `0`.
 
-Par exemple, nous appelons ici `regexp.test` à deux reprises sur la même chaîne de texte, and le second appel échoue: 
+Par exemple, nous appelons ici `regexp.test` à deux reprises sur la même chaîne de texte, and le second appel échoue:
 
 ```js run
 let regexp = /javascript/g;  // (création d'une nouvelle regexp: regexp.lastIndex=0)
@@ -360,7 +360,7 @@ alert( regexp.test("javascript") ); // true (maintenant regexp.lastIndex=10)
 alert( regexp.test("javascript") ); // false
 ```
 
-C'est exactement parce que `regexp.lastIndex` n'est pas `0` lors du second test.  
+C'est exactement parce que `regexp.lastIndex` n'est pas `0` lors du second test.
 
-Afin de contourner cela, nous pouvons réinitialiser `regexp.lastIndex = 0` avant chaque recherche. Ou, au lieu d'appeler la méthode sur une regexp, nous pouvons utiliser les méthodes de l'objet String `str.match/search/...`, qui n'utilisent pas `lastIndex`. 
+Afin de contourner cela, nous pouvons réinitialiser `regexp.lastIndex = 0` avant chaque recherche. Ou, au lieu d'appeler la méthode sur une regexp, nous pouvons utiliser les méthodes de l'objet String `str.match/search/...`, qui n'utilisent pas `lastIndex`.
 ````


### PR DESCRIPTION
Apporte diverses corrections globales à tout le tutoriel :

- Corrige le terme **_language_** en **_langage_** dans tout le tutoriel.
- Corrige aussi certaines mauvaises traductions de **_language_** en anglais en **_langue_** en français.
- Corrige certains termes **_Javascript_** en **_JavaScript_**.
- Quelques autres petites corrections de mise en forme.