### PR TITLE
docs: Mise à jour d'un lien dans le README pour pointer directement s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ce dépôt héberge le contenu français du tutoriel JavaScript moderne, publié
 
 Aidez-nous à améliorer la traduction.
 
-- Consultez l'[issue](https://github.com/javascript-tutorial/fr.javascript.info/issues) nommée "Translate Progress".
+- Consultez l'[issue](https://github.com/javascript-tutorial/fr.javascript.info/issues/3).
 - Choisissez un article non coché que vous souhaitez traduire.
 - Répondez à l'issue avec uniquement le titre sans aucun autre ajout pour informer le bot et le mainteneur que vous le traduisez.
 - Forkez le repository, traduisez et envoyez un PR (pull requests) lorsque vous avez terminé.


### PR DESCRIPTION
Mise à jour d'un lien dans le README pour pointer directement sur l'issue qui suit l'avancement global.

L'ancien lien redirigeait sur la liste de toutes les issues et demandait de rechercher manuellement l'issue nommée 'Translate Progress', mais aucune issue ne porte ce nom exact (c'est l'[issue#3](https://github.com/javascript-tutorial/fr.javascript.info/issues/3))