### PR TITLE
Translate two missing sentences in the article 'promise-error-handling'

### DIFF
--- a/1-js/11-async/04-promise-error-handling/article.md
+++ b/1-js/11-async/04-promise-error-handling/article.md
@@ -102,7 +102,7 @@ Dans un `try...catch` classique nous pouvons analyser l'erreur et peut-être la 
 
 Si nous utilisons `throw` dans `.catch`, alors le contrôle passe au gestionnaire d'erreur suivant qui est plus proche. Et si nous gérons l'erreur et finissons normalement, alors elle continue jusqu'au gestionnaire `.then` le plus proche.
 
-In the example below the `.catch` successfully handles the error:
+Dans l’exemple ci-dessous, le `.catch` gère correctement l’erreur:
 
 ```js run
 // l'exécution: catch -> then
@@ -149,7 +149,7 @@ new Promise((resolve, reject) => {
 });
 ```
 
-The execution jumps from the first `.catch` `(*)` to the next one `(**)` down the chain.
+L’exécution passe du premier `.catch` `(*)` au suivant `(**)` plus bas dans la chaîne.
 
 ## Rejets non traités
 

--- a/1-js/11-async/05-promise-api/article.md
+++ b/1-js/11-async/05-promise-api/article.md
@@ -219,15 +219,15 @@ La première promesse a été la plus rapide, donc, elle est devenue le résulta
 
 ## Promise.any
 
-Similar to `Promise.race`, but waits only for the first fulfilled promise and gets its result. If all of the given promises are rejected, then the returned promise is rejected with [`AggregateError`](mdn:js/AggregateError) - a special error object that stores all promise errors in its `errors` property.
+Semblable à `Promise.race`, mais attend uniquement la première promesse résolue et récupère son résultat. Si toutes les promesses données sont rejetées, alors la promesse retournée est rejetée avec un [`AggregateError`](mdn:js/AggregateError) - un objet d'erreur spécial qui stocke toutes les erreurs des promesses dans sa propriété `errors`.
 
-The syntax is:
+La syntaxe est :
 
 ```js
 let promise = Promise.any(iterable);
 ```
 
-For instance, here the result will be `1`:
+Par exemple, ici le résultat sera `1` :
 
 ```js run
 Promise.any([
@@ -237,9 +237,9 @@ Promise.any([
 ]).then(alert); // 1
 ```
 
-The first promise here was fastest, but it was rejected, so the second promise became the result. After the first fulfilled promise "wins the race", all further results are ignored.
+La première promesse ici a été la plus rapide, mais elle a été rejetée, donc la deuxième promesse est devenue le résultat. Une fois que la première promesse remplie "remporte la course", tous les résultats suivants sont ignorés.
 
-Here's an example when all promises fail:
+Voici un exemple où toutes les promesses échouent :
 
 ```js run
 Promise.any([
@@ -252,7 +252,7 @@ Promise.any([
 });
 ```
 
-As you can see, error objects for failed promises are available in the `errors` property of the `AggregateError` object.
+Comme vous pouvez le voir, les objets d’erreur des promesses échouées sont disponibles dans la propriété `errors` de l’objet `AggregateError`.
 
 ## Promise.resolve/reject
 


### PR DESCRIPTION
This pull request completes the French translation of the article promise-error-handling by translating two missing sentences that were still in English.

**Sentence 1:**
In the example below the .catch successfully handles the error:
Dans l’exemple ci-dessous, le .catch gère correctement l’erreur.

**Sentence 2:**
The execution jumps from the first .catch (*) to the next one (**) down the chain.
L’exécution passe du premier .catch (*) au suivant (**) plus bas dans la chaîne.

Linked to issue: #510